### PR TITLE
:sparkles: [feat] #11 Spring Security & JWT 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     // lombok
     compileOnly 'org.projectlombok:lombok'
@@ -36,6 +37,17 @@ dependencies {
     // database
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // Validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    //JWT
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+    //Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/sopt/bbangzip/common/annotation/UserId.java
+++ b/src/main/java/com/sopt/bbangzip/common/annotation/UserId.java
@@ -1,0 +1,22 @@
+package com.sopt.bbangzip.common.annotation;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+    /*
+    컨트롤러에서 JWT의 Access Token에 저장된 userId를 매개변수로
+    편리하게 주입 받을 수 있도록 도와주는 커스텀 어노테이션
+    */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "T(com.sopt.bbangzip.security.utils.SecurityUtils).checkPrincipal(#this)")
+public @interface UserId {
+    /*
+    런타임에 SecurityUtils 에 있는 checkPrincipal 메서드를 호출한다.
+    우리는 Null 검사(로그인 하지 않고 API 호출할 때 NPE) 할 필요 없이, 깔끔하게 접근 가능!
+     */
+}

--- a/src/main/java/com/sopt/bbangzip/common/constants/AuthConstant.java
+++ b/src/main/java/com/sopt/bbangzip/common/constants/AuthConstant.java
@@ -1,5 +1,21 @@
 package com.sopt.bbangzip.common.constants;
 
 public class AuthConstant {
-    // Spring Security 설정 시 쓸 상수를 모아놓는 클래스입니다.
+    public static final String USER_ID_CLAIM_NAME = "uid";
+    public static final String BEARER_PREFIX = "Bearer ";
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String ANONYMOUS_USER = "anonymousUser";
+    public static final String CHARACTER_TYPE = "utf-8";
+
+    /*
+    인증(회원가입, 로그인) 전 단계의 API 들을 화이트리스트에 등록.
+    이 배열에 포함된 경로들은 인증 없이 접근이 가능합니다.
+    현재는 구현 중이기 때문에, 모든 경로에 대해서 허용해 준 상태입니다!
+     */
+    public static final String[] AUTH_WHITE_LIST = {
+            "/api/v1/**"
+    };
+
+    private AuthConstant() { // 이 클래스의 인스턴스 생성을 막기 위해 private 생성자
+    }
 }

--- a/src/main/java/com/sopt/bbangzip/common/constants/AuthConstant.java
+++ b/src/main/java/com/sopt/bbangzip/common/constants/AuthConstant.java
@@ -6,6 +6,7 @@ public class AuthConstant {
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String ANONYMOUS_USER = "anonymousUser";
     public static final String CHARACTER_TYPE = "utf-8";
+    public static final String CONTENT_TYPE = "application/json";
 
     /*
     인증(회원가입, 로그인) 전 단계의 API 들을 화이트리스트에 등록.

--- a/src/main/java/com/sopt/bbangzip/common/exception/code/ErrorCode.java
+++ b/src/main/java/com/sopt/bbangzip/common/exception/code/ErrorCode.java
@@ -11,9 +11,15 @@ public enum ErrorCode implements BbangzipErrorCode{
 
     // 400
     INVALID_ARGUMENTS(HttpStatus.BAD_REQUEST, "error", "인자의 형식이 올바르지 않습니다."),
+    WRONG_ENTRY_POINT(HttpStatus.BAD_REQUEST, "error", "잘못된 요청입니다."),
 
     // 401
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "error", "인증되지 않은 사용자입니다."),
+    MALFORMED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "error", "잘못된 형식의 토큰입니다."),
+    TYPE_ERROR_JWT_TOKEN(HttpStatus.BAD_REQUEST, "error", "올바른 타입의 JWT 토큰이 아닙니다."),
+    EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "error", "만료된 토큰입니다."),
+    UNSUPPORTED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "error", "지원하지 않는 형식의 토큰입니다."),
+    UNKNOWN_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "error", "알 수 없는 인증 토큰 오류가 발생했습니다."),
 
     // 403
     FORBIDDEN(HttpStatus.FORBIDDEN, "error", "접근 권한이 없습니다."),

--- a/src/main/java/com/sopt/bbangzip/domain/token/api/JwtTokensDto.java
+++ b/src/main/java/com/sopt/bbangzip/domain/token/api/JwtTokensDto.java
@@ -1,0 +1,9 @@
+package com.sopt.bbangzip.domain.token.api;
+
+import lombok.Builder;
+
+@Builder
+public record JwtTokensDto(
+        String accessToken,
+        String refreshToken
+) { }

--- a/src/main/java/com/sopt/bbangzip/domain/token/entity/Token.java
+++ b/src/main/java/com/sopt/bbangzip/domain/token/entity/Token.java
@@ -1,0 +1,27 @@
+package com.sopt.bbangzip.domain.token.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Getter
+@RedisHash(value="token", timeToLive = 60 * 60 * 24 * 14)
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+public class Token {
+
+    @Id
+    private Long id;
+
+    @Indexed
+    private String refreshToken;
+
+    @Builder
+    public Token(Long id, String refreshToken) {
+        this.id = id;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/sopt/bbangzip/domain/token/repository/TokenRepository.java
+++ b/src/main/java/com/sopt/bbangzip/domain/token/repository/TokenRepository.java
@@ -1,0 +1,7 @@
+package com.sopt.bbangzip.domain.token.repository;
+
+import com.sopt.bbangzip.domain.token.entity.Token;
+import org.springframework.data.repository.CrudRepository;
+
+public interface TokenRepository extends CrudRepository<Token, Long> {
+}

--- a/src/main/java/com/sopt/bbangzip/domain/token/repository/TokenRepository.java
+++ b/src/main/java/com/sopt/bbangzip/domain/token/repository/TokenRepository.java
@@ -3,5 +3,12 @@ package com.sopt.bbangzip.domain.token.repository;
 import com.sopt.bbangzip.domain.token.entity.Token;
 import org.springframework.data.repository.CrudRepository;
 
+import java.util.Optional;
+
 public interface TokenRepository extends CrudRepository<Token, Long> {
+
+    // 필요 없으면 추후에 지우기
+    Optional<Token> findByRefreshToken(final String refreshToken);
+
+    Optional<Token> findById(final Long id);
 }

--- a/src/main/java/com/sopt/bbangzip/security/JwtUtil.java
+++ b/src/main/java/com/sopt/bbangzip/security/JwtUtil.java
@@ -1,4 +1,0 @@
-package com.sopt.bbangzip.security;
-
-public class JwtUtil {
-}

--- a/src/main/java/com/sopt/bbangzip/security/config/SecurityConfig.java
+++ b/src/main/java/com/sopt/bbangzip/security/config/SecurityConfig.java
@@ -1,0 +1,59 @@
+package com.sopt.bbangzip.security.config;
+
+import com.sopt.bbangzip.common.constants.AuthConstant;
+import com.sopt.bbangzip.security.exception.JwtAuthenticationEntryPoint;
+import com.sopt.bbangzip.security.filter.ExceptionHandlerFilter;
+import com.sopt.bbangzip.security.filter.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final ExceptionHandlerFilter exceptionHandlerFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                // API 서버 구성하므로 csrf 보호 비활성화
+                .csrf(AbstractHttpConfigurer::disable)
+                // 폼 로그인 비활성화
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                // 세션 사용 안함 == stateless
+                .sessionManagement(sessionManagementConfigurer ->
+                        sessionManagementConfigurer
+                                .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                // 인증 실패 시 예외 처리를 위해, 앞서 만들어 두었던 handler 등록!
+                .exceptionHandling(exception ->
+                {
+                    exception.authenticationEntryPoint(jwtAuthenticationEntryPoint);
+                });
+
+
+        // 화이트리스트에 등록한 요청의 경우엔 허용, 나머지 API 들에 대해서는 인증 진행한다.
+        http.authorizeHttpRequests(auth -> {
+                    auth
+                            .requestMatchers(AuthConstant.AUTH_WHITE_LIST).permitAll()
+                            .anyRequest()
+                            .authenticated();
+        })
+                // 필터 등록
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(exceptionHandlerFilter, JwtAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/sopt/bbangzip/security/exception/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/sopt/bbangzip/security/exception/JwtAuthenticationEntryPoint.java
@@ -1,6 +1,7 @@
 package com.sopt.bbangzip.security.exception;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sopt.bbangzip.common.constants.AuthConstant;
 import com.sopt.bbangzip.common.dto.ResponseDto;
 import com.sopt.bbangzip.common.exception.code.BbangzipErrorCode;
 import com.sopt.bbangzip.common.exception.code.ErrorCode;
@@ -18,7 +19,6 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
-
     /*
     필터에서 인증이나 인가 통과하지 못했을 떄, Handle 할 클래스
     인증 실패 시, Unauthorized 에러를 리턴할 EntryPoint
@@ -33,19 +33,16 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
             AuthenticationException authException
     ) throws IOException, ServletException {
 
-        // 필터나 다른 로직에서 request.setAttribute("exception", ...)로
-        // 미리 설정해둔 에러 코드를 가져와 본다.
         BbangzipErrorCode errorCode = (BbangzipErrorCode) request.getAttribute("exception");
 
         // 만약 에러 코드가 없으면 기본값으로 처리
         if (errorCode == null) {
-            // 에러 코드 enum 중 'WRONG_ENTRY_POINT' 같은 것을 하나 기본값으로 둔다고 가정
             errorCode = ErrorCode.WRONG_ENTRY_POINT;
         }
 
         // JSON 형태로 응답 내려주기
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
+        response.setContentType(AuthConstant.CONTENT_TYPE);
+        response.setCharacterEncoding(AuthConstant.CHARACTER_TYPE);
         response.setStatus(errorCode.getHttpStatus().value());
         response.getWriter().write(
                 objectMapper.writeValueAsString(ResponseDto.fail(errorCode))

--- a/src/main/java/com/sopt/bbangzip/security/exception/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/sopt/bbangzip/security/exception/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,54 @@
+package com.sopt.bbangzip.security.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sopt.bbangzip.common.dto.ResponseDto;
+import com.sopt.bbangzip.common.exception.code.BbangzipErrorCode;
+import com.sopt.bbangzip.common.exception.code.ErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+
+    /*
+    필터에서 인증이나 인가 통과하지 못했을 떄, Handle 할 클래스
+    인증 실패 시, Unauthorized 에러를 리턴할 EntryPoint
+    */
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException, ServletException {
+
+        // 필터나 다른 로직에서 request.setAttribute("exception", ...)로
+        // 미리 설정해둔 에러 코드를 가져와 본다.
+        BbangzipErrorCode errorCode = (BbangzipErrorCode) request.getAttribute("exception");
+
+        // 만약 에러 코드가 없으면 기본값으로 처리
+        if (errorCode == null) {
+            // 에러 코드 enum 중 'WRONG_ENTRY_POINT' 같은 것을 하나 기본값으로 둔다고 가정
+            errorCode = ErrorCode.WRONG_ENTRY_POINT;
+        }
+
+        // JSON 형태로 응답 내려주기
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.getWriter().write(
+                objectMapper.writeValueAsString(ResponseDto.fail(errorCode))
+        );
+    }
+}

--- a/src/main/java/com/sopt/bbangzip/security/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/com/sopt/bbangzip/security/filter/ExceptionHandlerFilter.java
@@ -1,0 +1,71 @@
+package com.sopt.bbangzip.security.filter;
+
+import com.sopt.bbangzip.common.exception.base.BusinessException;
+import com.sopt.bbangzip.common.exception.code.BbangzipErrorCode;
+import com.sopt.bbangzip.common.exception.code.ErrorCode;
+import com.sopt.bbangzip.security.jwt.ErrorResponseWriter;
+import com.sopt.bbangzip.security.jwt.ExceptionLogger;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+
+// 1번째로 구현
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+
+    private final ExceptionLogger exceptionLogger;
+    private final ErrorResponseWriter errorResponseWriter;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (AuthenticationException authEx) {
+            // AuthenticationException이 발생하면, EntryPoint가 대신 처리하도록 요청 속성에 세팅 후 재던짐
+            BbangzipErrorCode errorCode = mapExceptionToErrorCode(authEx);
+            request.setAttribute("exception", errorCode);
+
+            // Spring Security 흐름상 EntryPoint로 넘기기 위해 예외를 다시 던진다
+            throw authEx;
+        } catch (Exception e) {
+            // 나머지 예외는 여기서 직접 JSON 응답 작성
+            handleException(response, e);
+        }
+    }
+
+    private void handleException(HttpServletResponse response, Exception e) {
+        BbangzipErrorCode errorCode = mapExceptionToErrorCode(e);
+        exceptionLogger.log(errorCode, e);
+        errorResponseWriter.write(response, errorCode);
+    }
+
+    private BbangzipErrorCode mapExceptionToErrorCode(Exception e) {
+        if (e instanceof MalformedJwtException) return ErrorCode.MALFORMED_JWT_TOKEN;
+        if (e instanceof IllegalArgumentException) return ErrorCode.TYPE_ERROR_JWT_TOKEN;
+        if (e instanceof ExpiredJwtException) return ErrorCode.EXPIRED_JWT_TOKEN;
+        if (e instanceof UnsupportedJwtException) return ErrorCode.UNSUPPORTED_JWT_TOKEN;
+        if (e instanceof JwtException) return ErrorCode.UNKNOWN_JWT_TOKEN;
+        if (e instanceof BusinessException) return ((BusinessException) e).getErrorCode();
+        return ErrorCode.INTERNAL_SERVER_ERROR;
+    }
+}

--- a/src/main/java/com/sopt/bbangzip/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sopt/bbangzip/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,46 @@
+package com.sopt.bbangzip.security.filter;
+
+import com.sopt.bbangzip.security.jwt.JwtTokenProvider;
+import com.sopt.bbangzip.security.jwt.UserAuthenticationFactory;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserAuthenticationFactory userAuthenticationFactory;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+        // 요청의 헤더에서 토큰 찾아옴
+        final String token = jwtTokenProvider.getJwtFromRequest(request);
+        //토큰 있으면 -> 토큰으로부터 유저 정보 가져와서 -> 인증 객체 생성
+        if (StringUtils.hasText(token)) {
+            log.info("====================token: {}", token);
+
+            Claims claims = jwtTokenProvider.getBody(token);
+            log.info("====================claim: {}", claims);
+
+            userAuthenticationFactory.authenticateUser(claims, request);
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/sopt/bbangzip/security/filter/UserAuthentication.java
+++ b/src/main/java/com/sopt/bbangzip/security/filter/UserAuthentication.java
@@ -1,0 +1,32 @@
+package com.sopt.bbangzip.security.filter;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+
+/**
+ * 토근의 인증을 위한 사용자 정의 Authentication 객체 (서비스 인증 주채)
+  */
+public class UserAuthentication extends AbstractAuthenticationToken {
+
+    private final Long userId;
+
+    public UserAuthentication(Long userId) {
+        super(null); // authorities를 null로 처리
+        this.userId = userId;
+        setAuthenticated(true); // 인증된 상태로 설정
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return userId; // principal로 userId 반환
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null; // credentials는 사용하지 않음
+    }
+
+    // userId 만 사용해서 UserAuthentication 객체 생성
+    public static UserAuthentication createUserAuthentication(Long userId) {
+        return new UserAuthentication(userId);
+    }
+}

--- a/src/main/java/com/sopt/bbangzip/security/jwt/ErrorResponseWriter.java
+++ b/src/main/java/com/sopt/bbangzip/security/jwt/ErrorResponseWriter.java
@@ -1,0 +1,35 @@
+package com.sopt.bbangzip.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sopt.bbangzip.common.constants.AuthConstant;
+import com.sopt.bbangzip.common.dto.ResponseDto;
+import com.sopt.bbangzip.common.exception.code.BbangzipErrorCode;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ErrorResponseWriter {
+
+    private final ObjectMapper objectMapper;
+
+    public void write(HttpServletResponse response, BbangzipErrorCode errorCode) {
+        try {
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding(AuthConstant.CHARACTER_TYPE);
+            response.setStatus(errorCode.getHttpStatus().value());
+
+            PrintWriter writer = response.getWriter();
+            writer.write(objectMapper.writeValueAsString(ResponseDto.fail(errorCode)));
+        } catch (IOException e) {
+            log.error("Error writing response: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/sopt/bbangzip/security/jwt/ExceptionLogger.java
+++ b/src/main/java/com/sopt/bbangzip/security/jwt/ExceptionLogger.java
@@ -1,0 +1,18 @@
+package com.sopt.bbangzip.security.jwt;
+
+import com.sopt.bbangzip.common.exception.code.BbangzipErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class ExceptionLogger {
+
+    public void log(BbangzipErrorCode errorCode, Exception e) {
+        if (errorCode.getHttpStatus().is4xxClientError()) {
+            log.warn("Client error [{}]: {}", errorCode.getCode(), e.getMessage());
+        } else if (errorCode.getHttpStatus().is5xxServerError()) {
+            log.error("Server error [{}]: {}", errorCode.getCode(), e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/sopt/bbangzip/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sopt/bbangzip/security/jwt/JwtTokenProvider.java
@@ -70,7 +70,6 @@ public class JwtTokenProvider implements InitializingBean {
                 .compact();
     }
 
-
     // 토큰을 파싱하고 JWS 검증, JWT의 클레임 반환
     public Claims getBody(final String token) {
         return Jwts.parserBuilder()

--- a/src/main/java/com/sopt/bbangzip/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sopt/bbangzip/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,91 @@
+package com.sopt.bbangzip.security.jwt;
+
+import com.sopt.bbangzip.common.constants.AuthConstant;
+import com.sopt.bbangzip.domain.token.api.JwtTokensDto;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Date;
+
+/*
+   사용자 ID 사용해서 JWT 토큰 생성하는 클래스
+*/
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider implements InitializingBean {
+
+    @Value("${jwt.secret-key}")
+    private String secretKey;
+
+    @Value("${jwt.access-token-expire-time}")
+    private long ACCESS_TOKEN_EXPIRE_TIME;
+
+    @Value("${jwt.refresh-token-expire-time}")
+    @Getter
+    private long REFRESH_TOKEN_EXPIRE_TIME;
+
+    // JWT 서명을 위한 HMAC 키 객체
+    private Key key;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    // accessToken, RefreshToken 만들어서 반환 !!
+    public JwtTokensDto issueTokens(final long userId) {
+        return JwtTokensDto.builder()
+                .accessToken(generateToken(userId, ACCESS_TOKEN_EXPIRE_TIME))
+                .refreshToken(generateToken(userId, REFRESH_TOKEN_EXPIRE_TIME))
+                .build();
+    }
+
+    // JWT 토큰 생성
+    public String generateToken(final long userId, final long tokenExpirationTime) {
+        final Date now = new Date(System.currentTimeMillis());
+        final Date expirationTime = new Date(System.currentTimeMillis()+tokenExpirationTime);
+
+        final Claims claims = Jwts.claims()
+                .setIssuedAt(now) // 토큰 발행 시간을 지금으로
+                .setExpiration(expirationTime); // 토큰 만료 시간
+
+        claims.put(AuthConstant.USER_ID_CLAIM_NAME, userId);
+
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setClaims(claims)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+
+    // 토큰을 파싱하고 JWS 검증, JWT의 클레임 반환
+    public Claims getBody(final String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    // 요청의 헤더에서 토큰을 찾아주는 함수
+    public String getJwtFromRequest(final HttpServletRequest request) {
+        String bearerToken = request.getHeader(AuthConstant.AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(AuthConstant.BEARER_PREFIX)) {
+            return bearerToken.substring(AuthConstant.BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/sopt/bbangzip/security/jwt/UserAuthenticationFactory.java
+++ b/src/main/java/com/sopt/bbangzip/security/jwt/UserAuthenticationFactory.java
@@ -1,0 +1,22 @@
+package com.sopt.bbangzip.security.jwt;
+
+import com.sopt.bbangzip.common.constants.AuthConstant;
+import com.sopt.bbangzip.security.filter.UserAuthentication;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserAuthenticationFactory {
+
+    public void authenticateUser(Claims claims, HttpServletRequest request) {
+        Long userId = claims.get(AuthConstant.USER_ID_CLAIM_NAME, Long.class);
+
+        UserAuthentication authentication = UserAuthentication.createUserAuthentication(userId);
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}

--- a/src/main/java/com/sopt/bbangzip/security/utils/SecurityUtils.java
+++ b/src/main/java/com/sopt/bbangzip/security/utils/SecurityUtils.java
@@ -1,0 +1,16 @@
+package com.sopt.bbangzip.security.utils;
+
+import com.sopt.bbangzip.common.constants.AuthConstant;
+import com.sopt.bbangzip.common.exception.base.UnAuthorizedException;
+import com.sopt.bbangzip.common.exception.code.ErrorCode;
+
+// Null check 대행할 유틸 클래스
+public class SecurityUtils {
+
+    public static Object checkPrincipal(final Object principal) {
+        if (AuthConstant.ANONYMOUS_USER.equals(principal)) {
+            throw new UnAuthorizedException(ErrorCode.UNAUTHORIZED);
+        }
+        return principal;
+    }
+}

--- a/src/main/java/com/sopt/bbangzip/test/TestController.java
+++ b/src/main/java/com/sopt/bbangzip/test/TestController.java
@@ -1,18 +1,38 @@
 package com.sopt.bbangzip.test;
 
+import com.sopt.bbangzip.common.annotation.UserId;
+import com.sopt.bbangzip.domain.token.api.JwtTokensDto;
+import com.sopt.bbangzip.security.jwt.JwtTokenProvider;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/test")
 @RequiredArgsConstructor
 public class TestController {
 
+    private final JwtTokenProvider jwtTokenProvider;
+
     @GetMapping("/success")
     public ResponseEntity<TestDto> testSuccess(){
         return ResponseEntity.ok(TestDto.builder().content("얼른 자고싶어..").build());
+    }
+
+    @GetMapping("/token/{userId}")
+    public ResponseEntity<JwtTokensDto> testToken(
+            @PathVariable final Long userId
+    ) {
+        JwtTokensDto tokens = jwtTokenProvider.issueTokens(userId);
+        return ResponseEntity.ok(tokens);
+    }
+
+    @GetMapping("/security")
+    public ResponseEntity<TestDto> testSecurity(
+            @UserId final Long userId,
+            @Valid @RequestBody final TestSecurity testSecurity
+    ) {
+        return ResponseEntity.ok(TestDto.builder().content(testSecurity.name() + " " + userId).build());
     }
 }

--- a/src/main/java/com/sopt/bbangzip/test/TestSecurity.java
+++ b/src/main/java/com/sopt/bbangzip/test/TestSecurity.java
@@ -1,0 +1,10 @@
+package com.sopt.bbangzip.test;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TestSecurity(
+        @NotBlank
+        String name,
+        String email
+) {
+}


### PR DESCRIPTION
## Related issue 🛠
- closes #11 

&nbsp;
## Work Description ✏️
### 🍞 Spring Security 를 위한 기본 개념

**❓JWT 유효성 검사 과정**

1. 사용자가 요청에 JWT를 보내면, 서버에서 시크릿키 만을 이용해서 JWT의 토큰의 유효성을 체크합니다. (Signature)
2. 유효한 토큰이라면 사용자 인증을 거칩니다. (Payload)
3. 토큰의 만료기간 체크합니다.
4. 권한을 체크합니다.

&nbsp;
**❓JWT를 활용한 서비스 인증 방식의 핵심** 

모든 Spring Security Filter들의 인증 과정을 거치지 않고, JWT의 유효성을 검증할 수 있는 하나의 커스텀한 Filter를 거치도록 설계하여 사용자 인증을 구현할 수 있음.

→ JWT의 유효성을 검증할 수 있는 *커스텀 Filter*를 설계하고 Spring Security Filter 중 UsernamePasswordAuthenticationFilter(AuthenticationFilter) *앞 단에 해당 커스텀 Filter를 삽입*하여 사용자 인증 책임을 위임 !!

**UsernamePasswordAuthenticationFilter**

- ID와 PW를 사용하는 실제 Form 기반 유저 인증을 처리하는 Filter로, /login URL 요청 시 호출
- 인증 객체(Authentication 객체)를 만들어 입력받은 사용자의 ID와 PW를 저장하고 AuthenticationManager에게 인증 처리를 위임

**Authentication 객체**

- 인증 시 ID와 PW를 담고 인증 검증을 위해 전달되어 사용되는 인증의 주체
- 인증 후 최종 인증 결과를 담고 SecurityContext에 저장되어 전역적으로 참조 가능
- 사용자의 인증 정보를 저장하는 토큰의 개념


---

 

### 📁 **패키지 구조**

 기능별/역할별로 책임을 나누어 **JWT 인증** → **유저 정보 추출** → **Authentication 등록** → **예외 처리** 전 과정을 모듈별로 분리했습니다.

```groovy
ㄴ security                            
   ㄴ config                           (스프링 시큐리티 설정)
      ㄴ SecurityConfig                (SecurityFilterChain, 인증/인가 정책, 세션 전략 등 주요 설정)

   ㄴ exception                        (시큐리티 관련 예외 처리)
      ㄴ JwtAuthenticationEntryPoint   (인증 실패 시 401 Unauthorized 응답 내려주는 EntryPoint)

   ㄴ filter                           (커스텀 시큐리티 필터)
      ㄴ ExceptionHandlerFilter        (필터 체인 상단에서 예외 한 번에 처리)
      ㄴ JwtAuthenticationFilter       (JWT 토큰 검증 필터, 정상 시 Authentication 등록)
      ㄴ UserAuthentication            (커스텀 Authentication 객체, principal=userId 등)

   ㄴ jwt                              (JWT 관련 로직, 유틸)
      ㄴ JwtTokenProvider              (토큰 발급, 만료/파싱/검증 담당)
      ㄴ UserAuthenticationFactory     (토큰 검증 후 인증객체 생성, SecurityContextHolder에 저장)
      ㄴ ErrorResponseWriter           (에러 발생 시 JSON 응답 바디 작성)
      ㄴ ExceptionLogger               (에러 코드 기반 로깅 처리)

   ㄴ utils                            (시큐리티 보조 유틸)
      ㄴ SecurityUtils                 (principal 검사, @UserId 처리 등 공용 함수)
```

---

### 📝 Flow

✅ **HTTP Request 가 들어오면 Filter Chain 이 시작**

1. ExceptionHandlerFilter 먼저 동작
2.  다음으로 JwtAuthenticationFilter 동작.

&nbsp;

✅  **인증 성공 시 → SecurityContextHolder에 Authentication 저장**

1. UserAuthenticationFactory
    - JwtAuthenticationFilter가 토큰에서 추출한 Claims(토큰 내용)로부터 userId를 꺼냄
    - 커스텀 인증 객체를 만들고, 요청에 대한 정보도 담은 다음에 SecurityContextHolder.getContext().setAuthentication(authentication) 호출함
2. UserAuthentication
    - principal을 userId로만 쓰기 때문에 `UsernamePasswordAuthenticationToken` 대신 `AbstractAuthenticationToken` 를 extends 했습니다.
    → principal 을 userId 로만 씀
    - 컨트롤러 단에서 `@UserId` 파라미터를 이용해서 이 userId를 편하게 꺼내 쓸 수 있음!
        - 커스텀 어노테이션 `@UserId` 구현 참고 자료
           https://velog.io/@im_h_jo/Spring-Security%EC%97%90%EC%84%9C-%ED%98%84%EC%9E%AC-%EB%A1%9C%EA%B7%B8%EC%9D%B8%ED%95%9C-%EC%97%94%ED%8B%B0%ED%8B%B0%EB%A5%BC-%EB%B0%94%EB%A1%9C-%EB%B6%88%EB%9F%AC%EC%98%A4%EC%9E%90-null
            
&nbsp;
✅  **인증 실패 시 → 예외 처리**

1. JwtAuthenticationFilter 에서 토큰 검증 중 예외 발생 (ex. 토큰 누락, 잘못된 형식..)
2. 1번에서 발생한 예외를 ExceptionHandlerFilter가 캐치!
    - 만약 스프링 시큐리티가 다루는 AuthenticationException 계열이라면 → 재던짐(throw authEx)
    - 그 외 일반 예외라면 → handleException() 호출
4. 재던진 AuthenticationException은 Spring Security가 자동으로 JwtAuthenticationEntryPoint호출

**(+) 기타 예외 처리 관련 클래스들**

- ErrorResponseWriter
- ExceptionLogger : 예외 발생 시 warn/error 레벨로 로깅
- SecurityUtils : `@UserId` 어노테이션으로부터 principal 받아올 때 anonymousUser인 경우, UnAuthorizedException을 던지는 등 NPE 검사(로그인 안 된 상태 방지)를 수행.

&nbsp;

**✅ SecurityConfig**

앞서 만든 필터들을 등록한다.

&nbsp;

---

### Test 성공 화면
<img width="845" alt="image" src="https://github.com/user-attachments/assets/198d1d35-c7e9-4d03-8335-b65578140492" />
<img width="849" alt="image" src="https://github.com/user-attachments/assets/799dbc9b-95d1-450a-81f6-bbdf7d4f2fd8" />


&nbsp;
## Trouble Shooting ⚽️
application.yml 에서 on-profile 을 dev 로 명시적 지정해놓았더니 코드 실행에 에러가 발생했었음. 삭제해주니 정상 실행!
(추후에 여유로우면 트슈에 정리하도록 하겠습니다)

&nbsp;
## To Reviewers 📢
이해가 쉽도록 주석을 다 달아놓았습니다!
궁금한 점이 있다면 언제든지 물어봐주세용~!