### PR TITLE
✨ [feat] #24 과목 삭제하기 API 구현

### DIFF
--- a/src/main/java/com/sopt/bbangzip/common/exception/code/ErrorCode.java
+++ b/src/main/java/com/sopt/bbangzip/common/exception/code/ErrorCode.java
@@ -29,7 +29,7 @@ public enum ErrorCode implements BbangzipErrorCode{
     NOT_FOUND_USER(HttpStatus.NOT_FOUND,"error","존재하지 않는 사용자입니다."),
     DUPLICATED_SUBJECT(HttpStatus.NOT_FOUND, "error", "해당 학기에 과목명이 중복됩니다."),
     NOT_FOUND_USER_SUBJECT(HttpStatus.NOT_FOUND,"error","해당 학기에 유저가 등록한 과목이 없습니다"),
-
+    NOT_FOUND_SUBJECT(HttpStatus.NOT_FOUND, "error", "존재하지 않는 과목입니다."),
     // 500
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "error", "서버 내부 오류입니다."),
     ;

--- a/src/main/java/com/sopt/bbangzip/domain/subject/api/controller/SubjectController.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/api/controller/SubjectController.java
@@ -5,6 +5,7 @@ import com.sopt.bbangzip.common.dto.ResponseDto;
 import com.sopt.bbangzip.common.exception.base.DuplicateSubjectException;
 import com.sopt.bbangzip.common.exception.base.NotFoundException;
 import com.sopt.bbangzip.domain.subject.api.dto.request.SubjectCreateDto;
+import com.sopt.bbangzip.domain.subject.api.dto.request.SubjectDeleteDto;
 import com.sopt.bbangzip.domain.subject.service.SubjectService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,16 @@ public class SubjectController {
             @RequestBody @Valid final SubjectCreateDto subjectCreateDto
     ) {
         subjectService.createSubject(userId, subjectCreateDto);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 과목 삭제하기 API
+    @DeleteMapping("subjects")
+    public ResponseEntity<ResponseDto<Void>> deleteSubject(
+            @UserId final Long userId,
+            @RequestBody @Valid final SubjectDeleteDto subjectDeleteDto
+            ){
+        subjectService.deleteSubject(userId, subjectDeleteDto);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/subject/api/controller/SubjectController.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/api/controller/SubjectController.java
@@ -31,11 +31,11 @@ public class SubjectController {
     }
 
     // 과목 삭제하기 API
-    @DeleteMapping("subjects")
-    public ResponseEntity<ResponseDto<Void>> deleteSubject(
+    @DeleteMapping("/subjects")
+    public ResponseEntity<Void> deleteSubject(
             @UserId final Long userId,
             @RequestBody @Valid final SubjectDeleteDto subjectDeleteDto
-            ){
+    ) {
         subjectService.deleteSubject(userId, subjectDeleteDto);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/sopt/bbangzip/domain/subject/api/dto/request/SubjectDeleteDto.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/api/dto/request/SubjectDeleteDto.java
@@ -1,0 +1,5 @@
+package com.sopt.bbangzip.domain.subject.api.dto.request;
+
+import java.util.List;
+
+public record SubjectDeleteDto(int year, String semester, List<Long> subjectIds) {}

--- a/src/main/java/com/sopt/bbangzip/domain/subject/api/dto/request/SubjectDeleteDto.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/api/dto/request/SubjectDeleteDto.java
@@ -2,4 +2,9 @@ package com.sopt.bbangzip.domain.subject.api.dto.request;
 
 import java.util.List;
 
-public record SubjectDeleteDto(int year, String semester, List<Long> subjectIds) {}
+public record SubjectDeleteDto(
+        int year,
+        String semester,
+        List<Long> subjectIds
+) {
+}

--- a/src/main/java/com/sopt/bbangzip/domain/subject/repository/SubjectRepository.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/repository/SubjectRepository.java
@@ -11,9 +11,6 @@ import java.util.List;
 @Repository
 public interface SubjectRepository extends JpaRepository<Subject, Long> {
     boolean existsByUserSubjectAndSubjectName(UserSubject userSubject, String subjectName);
-
-
     // 특정 UserSubject ID와 과목 ID로 과목 조회
     List<Subject> findByIdInAndUserSubjectId(List<Long> subjectIds, Long userSubjectId);
-
 }

--- a/src/main/java/com/sopt/bbangzip/domain/subject/repository/SubjectRepository.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/repository/SubjectRepository.java
@@ -6,7 +6,14 @@ import com.sopt.bbangzip.domain.userSubject.entity.UserSubject;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface SubjectRepository extends JpaRepository<Subject, Long> {
     boolean existsByUserSubjectAndSubjectName(UserSubject userSubject, String subjectName);
+
+
+    // 특정 UserSubject ID와 과목 ID로 과목 조회
+    List<Subject> findByIdInAndUserSubjectId(List<Long> subjectIds, Long userSubjectId);
+
 }

--- a/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectRemover.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectRemover.java
@@ -20,7 +20,7 @@ import java.util.List;
 public class SubjectRemover {
     private final SubjectRepository subjectRepository;
 
-    public void removeSubjects(List<Subject> subjects) {
+    public final void removeSubjects(List<Subject> subjects) {
         subjectRepository.deleteAll(subjects);
     }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectRemover.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectRemover.java
@@ -1,4 +1,41 @@
 package com.sopt.bbangzip.domain.subject.service;
 
+import com.sopt.bbangzip.common.exception.base.NotFoundException;
+import com.sopt.bbangzip.common.exception.code.ErrorCode;
+import com.sopt.bbangzip.domain.subject.api.dto.request.SubjectDeleteDto;
+import com.sopt.bbangzip.domain.subject.entity.Subject;
+import com.sopt.bbangzip.domain.subject.repository.SubjectRepository;
+import com.sopt.bbangzip.domain.userSubject.entity.UserSubject;
+import com.sopt.bbangzip.domain.userSubject.repository.UserSubjectRepository;
+import com.sopt.bbangzip.domain.userSubject.service.UserSubjectRetriever;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+@Component
+@RequiredArgsConstructor
 public class SubjectRemover {
+
+
+    private final SubjectRetriever subjectRetriever;
+    private final SubjectRepository subjectRepository;
+
+    private final UserSubjectRetriever userSubjectRetriever;
+    private final UserSubjectRepository userSubjectRepository;
+
+    @Transactional
+    public void removeSubjects(Long userId, SubjectDeleteDto subjectDeleteDto) {
+        // 주어진 연도와 학기에 대한 UserSubject 조회
+        UserSubject userSubject = subjectRetriever.findByUserIdAndYearAndSemester(userId, subjectDeleteDto.year(), subjectDeleteDto.semester());
+
+        // 삭제할 과목 조회
+        List<Subject> subjects = subjectRetriever.findByIdInAndUserSubjectId(subjectDeleteDto.subjectIds(), userSubject.getId());
+
+        // 과목 삭제
+        subjectRepository.deleteAll(subjects);
+    }
 }
+

--- a/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectRemover.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectRemover.java
@@ -18,23 +18,9 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 public class SubjectRemover {
-
-
-    private final SubjectRetriever subjectRetriever;
     private final SubjectRepository subjectRepository;
 
-    private final UserSubjectRetriever userSubjectRetriever;
-    private final UserSubjectRepository userSubjectRepository;
-
-    @Transactional
-    public void removeSubjects(Long userId, SubjectDeleteDto subjectDeleteDto) {
-        // 주어진 연도와 학기에 대한 UserSubject 조회
-        UserSubject userSubject = subjectRetriever.findByUserIdAndYearAndSemester(userId, subjectDeleteDto.year(), subjectDeleteDto.semester());
-
-        // 삭제할 과목 조회
-        List<Subject> subjects = subjectRetriever.findByIdInAndUserSubjectId(subjectDeleteDto.subjectIds(), userSubject.getId());
-
-        // 과목 삭제
+    public void removeSubjects(List<Subject> subjects) {
         subjectRepository.deleteAll(subjects);
     }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectRetriever.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectRetriever.java
@@ -24,13 +24,13 @@ public class SubjectRetriever {
     }
 
     // UserSubject 조회
-    public UserSubject findByUserIdAndYearAndSemester(Long userId, int year, String semester) {
+    public final UserSubject findByUserIdAndYearAndSemester(Long userId, int year, String semester) {
         return userSubjectRepository.findByUserIdAndYearAndSemester(userId, year, semester)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_USER_SUBJECT));
     }
 
     // 과목 조회
-    public List<Subject> findByIdInAndUserSubjectId(List<Long> subjectIds, Long userSubjectId) {
+    public final List<Subject> findByIdInAndUserSubjectId(List<Long> subjectIds, Long userSubjectId) {
         List<Subject> subjects = subjectRepository.findByIdInAndUserSubjectId(subjectIds, userSubjectId);
         if (subjects.isEmpty()) {
             throw new NotFoundException(ErrorCode.NOT_FOUND_SUBJECT);

--- a/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectRetriever.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectRetriever.java
@@ -1,18 +1,40 @@
 package com.sopt.bbangzip.domain.subject.service;
 
+import com.sopt.bbangzip.common.exception.base.NotFoundException;
+import com.sopt.bbangzip.common.exception.code.ErrorCode;
+import com.sopt.bbangzip.domain.subject.entity.Subject;
 import com.sopt.bbangzip.domain.subject.repository.SubjectRepository;
 import com.sopt.bbangzip.domain.userSubject.entity.UserSubject;
+import com.sopt.bbangzip.domain.userSubject.repository.UserSubjectRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 public class SubjectRetriever {
 
     private final SubjectRepository subjectRepository;
+    private final UserSubjectRepository userSubjectRepository;
 
     // userSubject subjectName 에 해당하는 과목(Subject) 가 존재하는지 확인하는 메서드
     public boolean existsByUserSubjectAndSubjectName(UserSubject userSubject, String subjectName){
         return subjectRepository.existsByUserSubjectAndSubjectName(userSubject, subjectName);
+    }
+
+    // UserSubject 조회
+    public UserSubject findByUserIdAndYearAndSemester(Long userId, int year, String semester) {
+        return userSubjectRepository.findByUserIdAndYearAndSemester(userId, year, semester)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_USER_SUBJECT));
+    }
+
+    // 과목 조회
+    public List<Subject> findByIdInAndUserSubjectId(List<Long> subjectIds, Long userSubjectId) {
+        List<Subject> subjects = subjectRepository.findByIdInAndUserSubjectId(subjectIds, userSubjectId);
+        if (subjects.isEmpty()) {
+            throw new NotFoundException(ErrorCode.NOT_FOUND_SUBJECT);
+        }
+        return subjects;
     }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectSaver.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectSaver.java
@@ -2,6 +2,7 @@ package com.sopt.bbangzip.domain.subject.service;
 
 import com.sopt.bbangzip.domain.subject.entity.Subject;
 import com.sopt.bbangzip.domain.subject.repository.SubjectRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -12,6 +13,7 @@ public class SubjectSaver {
     private final SubjectRepository subjectRepository;
 
     // 과목 저장
+    @Transactional
     public void save(final Subject subject) {
         subjectRepository.save(subject);
     }

--- a/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectService.java
@@ -14,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -55,9 +57,13 @@ public class SubjectService {
         // 유저 검증
         userRetriever.findByUserId(userId);
 
+        // 주어진 연도와 학기에 대한 UserSubject 조회
+        UserSubject userSubject = subjectRetriever.findByUserIdAndYearAndSemester(userId, subjectDeleteDto.year(), subjectDeleteDto.semester());
+
+        // 삭제할 과목 조회
+        List<Subject> subjects = subjectRetriever.findByIdInAndUserSubjectId(subjectDeleteDto.subjectIds(), userSubject.getId());
+
         // SubjectRemover를 통해 삭제 처리
-        subjectRemover.removeSubjects(userId, subjectDeleteDto);
+        subjectRemover.removeSubjects(subjects);
     }
-
-
 }

--- a/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectService.java
@@ -3,6 +3,7 @@ package com.sopt.bbangzip.domain.subject.service;
 import com.sopt.bbangzip.common.exception.base.DuplicateSubjectException;
 import com.sopt.bbangzip.common.exception.code.ErrorCode;
 import com.sopt.bbangzip.domain.subject.api.dto.request.SubjectCreateDto;
+import com.sopt.bbangzip.domain.subject.api.dto.request.SubjectDeleteDto;
 import com.sopt.bbangzip.domain.subject.entity.Subject;
 import com.sopt.bbangzip.domain.user.entity.User;
 import com.sopt.bbangzip.domain.user.service.UserRetriever;
@@ -22,6 +23,7 @@ public class SubjectService {
 
     private final SubjectRetriever subjectRetriever;
     private final SubjectSaver subjectSaver;
+    private final SubjectRemover subjectRemover;
 
     private final UserSubjectRetriever userSubjectRetriever;
     private final UserSubjectSaver userSubjectSaver;
@@ -48,4 +50,14 @@ public class SubjectService {
         // subject 자체를 넘겨줘서 저장하기
         subjectSaver.save(subject);
     }
+
+    public void deleteSubject(Long userId, SubjectDeleteDto subjectDeleteDto) {
+        // 유저 검증
+        userRetriever.findByUserId(userId);
+
+        // SubjectRemover를 통해 삭제 처리
+        subjectRemover.removeSubjects(userId, subjectDeleteDto);
+    }
+
+
 }

--- a/src/main/java/com/sopt/bbangzip/domain/userSubject/repository/UserSubjectRepository.java
+++ b/src/main/java/com/sopt/bbangzip/domain/userSubject/repository/UserSubjectRepository.java
@@ -8,6 +8,14 @@ import java.util.Optional;
 
 @Repository
 public interface UserSubjectRepository extends JpaRepository<UserSubject, Long> {
+
+    // userId, year, semester를 통해 UserSubject 조회
     Optional<UserSubject> findByUserIdAndYearAndSemester(Long userId,  int year, String semester);
+
+    // userId와 userSubjectId로 UserSubject 조회
+    Optional<UserSubject> findByUserIdAndId(Long userId, Long userSubjectId);
+
+
+
 }
 

--- a/src/main/java/com/sopt/bbangzip/domain/userSubject/repository/UserSubjectRepository.java
+++ b/src/main/java/com/sopt/bbangzip/domain/userSubject/repository/UserSubjectRepository.java
@@ -14,8 +14,5 @@ public interface UserSubjectRepository extends JpaRepository<UserSubject, Long> 
 
     // userId와 userSubjectId로 UserSubject 조회
     Optional<UserSubject> findByUserIdAndId(Long userId, Long userSubjectId);
-
-
-
 }
 

--- a/src/main/java/com/sopt/bbangzip/domain/userSubject/service/UserSubjectRetriever.java
+++ b/src/main/java/com/sopt/bbangzip/domain/userSubject/service/UserSubjectRetriever.java
@@ -30,7 +30,4 @@ public class UserSubjectRetriever {
         return userSubjectRepository.findByUserIdAndId(userId, userSubjectId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_USER_SUBJECT));
     }
-
-
-
 }

--- a/src/main/java/com/sopt/bbangzip/domain/userSubject/service/UserSubjectRetriever.java
+++ b/src/main/java/com/sopt/bbangzip/domain/userSubject/service/UserSubjectRetriever.java
@@ -1,6 +1,9 @@
 package com.sopt.bbangzip.domain.userSubject.service;
 
+import com.sopt.bbangzip.common.exception.base.NotFoundException;
+import com.sopt.bbangzip.common.exception.code.ErrorCode;
 import com.sopt.bbangzip.domain.user.entity.User;
+import com.sopt.bbangzip.domain.user.repository.UserRepository;
 import com.sopt.bbangzip.domain.user.service.UserRetriever;
 import com.sopt.bbangzip.domain.userSubject.entity.UserSubject;
 import com.sopt.bbangzip.domain.userSubject.repository.UserSubjectRepository;
@@ -14,10 +17,20 @@ public class UserSubjectRetriever {
     private final UserSubjectRepository userSubjectRepository;
     private final UserRetriever userRetriever;
 
-    // 해당 userId 의 Year 와 Semester 에 해당하는 과목이 있는지 확인하는 애자나
+
+    // 해당 userId 의 Year 와 Semester 에 해당하는 과목이 있는지 확인
     public UserSubject findByUserIdAndYearAndSemester(Long userId, int year, String semester){
         User user = userRetriever.findByUserId(userId);
         return userSubjectRepository.findByUserIdAndYearAndSemester(userId, year, semester)
                 .orElseGet(() -> UserSubject.builder().user(user).year(year).semester(semester).build());
     }
+
+    // 특정 유저 ID와 UserSubject ID로 UserSubject 조회
+    public UserSubject findByUserIdAndId(Long userId, Long userSubjectId) {
+        return userSubjectRepository.findByUserIdAndId(userId, userSubjectId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_USER_SUBJECT));
+    }
+
+
+
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #24

## Work Description ✏️

과목 중에 n개의 과목을 삭제하는 DELETE API 입니다.

- [ ] 유저가 있는지 없는지 여부를 확인
- [ ] 유저가 있다면 해당 년도와 학기에 과목이 존재하는지 확인
- [ ]  해당 년도와 학기의 과목을 삭제

다음과 같은 흐름으로 과목을 삭제합니다.

![image](https://github.com/user-attachments/assets/f04acdf0-8da6-43da-b69e-fe8b21e4f8b3)


user_subject와 subject 테이블을 잠시 조인했습니다.

여기서 `2025` 년 `1` 학기에 해당되는 과목들을 모두 삭제해보겠습니다.

![image](https://github.com/user-attachments/assets/b54df269-94ae-4f97-89f1-f252c46165a8)

잘 삭제된 것을 확인할 수 있습니다.

![image](https://github.com/user-attachments/assets/fdc024fd-894c-4894-a5c8-ee26dcc4a635)


## Trouble Shooting ⚽️

학기 정보가 추가되기 전 API를 토대로 작업하다보니, 시간이 생각보다 더 소요되었습니다 ㅠㅠ
작업하기 전에 API 명세서를 꼼꼼히 확인하는 것도 좋을 것 같아요 !


## To Reviewers 📢

고치면 좋을 것들을 알려주세요 ! `Service` 단에서의 역할 분리가 잘 되었는지 궁금합니다.
