### PR TITLE
:sparkles: [feat] #26 리프레시 토큰으로 엑세스 토큰 재발급 로직 구현

### DIFF
--- a/src/main/java/com/sopt/bbangzip/common/exception/code/ErrorCode.java
+++ b/src/main/java/com/sopt/bbangzip/common/exception/code/ErrorCode.java
@@ -12,12 +12,14 @@ public enum ErrorCode implements BbangzipErrorCode{
     // 400
     INVALID_ARGUMENTS(HttpStatus.BAD_REQUEST, "error", "인자의 형식이 올바르지 않습니다."),
     WRONG_ENTRY_POINT(HttpStatus.BAD_REQUEST, "error", "잘못된 요청입니다."),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "error", "올바르지 않은 형식의 토큰입니다"),
 
     // 401
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "error", "인증되지 않은 사용자입니다."),
     MALFORMED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "error", "잘못된 형식의 토큰입니다."),
     TYPE_ERROR_JWT_TOKEN(HttpStatus.BAD_REQUEST, "error", "올바른 타입의 JWT 토큰이 아닙니다."),
     EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "error", "만료된 토큰입니다."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "error", "유효하지 않은 리프레시 토큰입니다."),
     UNSUPPORTED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "error", "지원하지 않는 형식의 토큰입니다."),
     UNKNOWN_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "error", "알 수 없는 인증 토큰 오류가 발생했습니다."),
 

--- a/src/main/java/com/sopt/bbangzip/domain/auth/AuthController.java
+++ b/src/main/java/com/sopt/bbangzip/domain/auth/AuthController.java
@@ -1,8 +1,12 @@
 package com.sopt.bbangzip.domain.auth;
 
 import com.sopt.bbangzip.common.annotation.UserId;
+import com.sopt.bbangzip.common.exception.base.NotFoundException;
+import com.sopt.bbangzip.common.exception.code.ErrorCode;
 import com.sopt.bbangzip.domain.token.api.JwtTokensDto;
 import com.sopt.bbangzip.domain.token.api.ReissueJwtTokensDto;
+import com.sopt.bbangzip.security.jwt.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     // 소셜 로그인 API
     @PostMapping("/user/auth/signin")
@@ -25,9 +30,14 @@ public class AuthController {
     // 리프레시 토큰 재발급 API
     @PostMapping("/user/auth/re-issue")
     public ResponseEntity<ReissueJwtTokensDto> reissueToken(
-            @UserId final long userId
+            @UserId final long userId,
+            HttpServletRequest request
     ){
-        return ResponseEntity.ok(authService.reissueToken(userId));
+        String refreshToken = jwtTokenProvider.getJwtFromRequest(request);
+        if (refreshToken == null) {
+            throw new NotFoundException(ErrorCode.INVALID_TOKEN);
+        }
+        return ResponseEntity.ok(authService.reissueToken(userId, refreshToken));
     }
 
     // 로그아웃 API (진행중)

--- a/src/main/java/com/sopt/bbangzip/domain/auth/AuthController.java
+++ b/src/main/java/com/sopt/bbangzip/domain/auth/AuthController.java
@@ -2,6 +2,7 @@ package com.sopt.bbangzip.domain.auth;
 
 import com.sopt.bbangzip.common.annotation.UserId;
 import com.sopt.bbangzip.domain.token.api.JwtTokensDto;
+import com.sopt.bbangzip.domain.token.api.ReissueJwtTokensDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,9 +22,9 @@ public class AuthController {
         return ResponseEntity.ok(authService.kakaoLogin(code));
     }
 
-    // 리프레시 토큰 재발급 API (진행중)
+    // 리프레시 토큰 재발급 API
     @PostMapping("/user/auth/re-issue")
-    public ResponseEntity<JwtTokensDto> reissueToken(
+    public ResponseEntity<ReissueJwtTokensDto> reissueToken(
             @UserId final long userId
     ){
         return ResponseEntity.ok(authService.reissueToken(userId));

--- a/src/main/java/com/sopt/bbangzip/domain/auth/AuthService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/auth/AuthService.java
@@ -1,6 +1,7 @@
 package com.sopt.bbangzip.domain.auth;
 
 import com.sopt.bbangzip.domain.token.api.JwtTokensDto;
+import com.sopt.bbangzip.domain.token.api.ReissueJwtTokensDto;
 import com.sopt.bbangzip.domain.token.entity.Token;
 import com.sopt.bbangzip.domain.token.service.TokenRemover;
 import com.sopt.bbangzip.domain.token.service.TokenRetriever;
@@ -63,8 +64,11 @@ public class AuthService {
         return jwtTokensDto;
     }
 
-    public JwtTokensDto reissueToken(final long userId) {
-        return null;
+    @Transactional
+    public ReissueJwtTokensDto reissueToken(final long userId) {
+        ReissueJwtTokensDto tokensDto = jwtTokenProvider.reissueTokens(userId);
+        tokenSaver.save(Token.builder().id(userId).refreshToken(tokensDto.refreshToken()).build());
+        return tokensDto;
     }
 
     public void logout(final long userId) {

--- a/src/main/java/com/sopt/bbangzip/domain/auth/AuthService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/auth/AuthService.java
@@ -65,16 +65,28 @@ public class AuthService {
     }
 
     @Transactional
-    public ReissueJwtTokensDto reissueToken(final long userId) {
+    public ReissueJwtTokensDto reissueToken(final long userId, final String refreshToken) {
+        // 리프레시 토큰인지 검증
+        jwtTokenProvider.validateRefreshToken(refreshToken);
+        if (tokenRetriever.findByRefreshToken(refreshToken).isEmpty()) {
+            throw new IllegalStateException("리프레시 토큰이 이미 사용되었거나 존재하지 않습니다.");
+        }
+
+        // 기존 리프레시 토큰 폐기
+        tokenRemover.removeRefreshToken(refreshToken);
+        // 새로운 엑세스 토큰, 리프레시 토큰 발급
         ReissueJwtTokensDto tokensDto = jwtTokenProvider.reissueTokens(userId);
+        // 새로운 리프레시 토큰 저장 후 반환
         tokenSaver.save(Token.builder().id(userId).refreshToken(tokensDto.refreshToken()).build());
         return tokensDto;
     }
 
+    @Transactional
     public void logout(final long userId) {
         return;
     }
 
+    @Transactional
     public void unlink(final long userId) {
         return;
     }

--- a/src/main/java/com/sopt/bbangzip/domain/token/api/ReissueJwtTokensDto.java
+++ b/src/main/java/com/sopt/bbangzip/domain/token/api/ReissueJwtTokensDto.java
@@ -1,0 +1,10 @@
+package com.sopt.bbangzip.domain.token.api;
+
+import lombok.Builder;
+
+@Builder
+public record ReissueJwtTokensDto(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/sopt/bbangzip/domain/token/service/TokenRemover.java
+++ b/src/main/java/com/sopt/bbangzip/domain/token/service/TokenRemover.java
@@ -9,4 +9,8 @@ import org.springframework.stereotype.Component;
 public class TokenRemover {
 
     private final TokenRepository tokenRepository;
+
+    public void removeRefreshToken(final String refreshToken) {
+        tokenRepository.findByRefreshToken(refreshToken).ifPresent(tokenRepository::delete);
+    }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/token/service/TokenRetriever.java
+++ b/src/main/java/com/sopt/bbangzip/domain/token/service/TokenRetriever.java
@@ -1,12 +1,19 @@
 package com.sopt.bbangzip.domain.token.service;
 
+import com.sopt.bbangzip.domain.token.entity.Token;
 import com.sopt.bbangzip.domain.token.repository.TokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
 public class TokenRetriever {
 
     private final TokenRepository tokenRepository;
+
+    public Optional<Token> findByRefreshToken(final String refreshToken) {
+        return tokenRepository.findByRefreshToken(refreshToken);
+    }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/user/service/UserRetriever.java
+++ b/src/main/java/com/sopt/bbangzip/domain/user/service/UserRetriever.java
@@ -1,6 +1,6 @@
 package com.sopt.bbangzip.domain.user.service;
 
-import com.sopt.bbangzip.common.exception.base.NotfoundException;
+import com.sopt.bbangzip.common.exception.base.NotFoundException;
 import com.sopt.bbangzip.common.exception.code.ErrorCode;
 import com.sopt.bbangzip.domain.user.entity.User;
 import com.sopt.bbangzip.domain.user.repository.UserRepository;
@@ -15,7 +15,7 @@ public class UserRetriever {
 
     public User findByUserId(final long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new NotfoundException(ErrorCode.NOT_FOUND_USER));
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_USER));
     }
 
     public User findByPlatformUserId(final Long platformUserId) {

--- a/src/main/java/com/sopt/bbangzip/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sopt/bbangzip/security/jwt/JwtTokenProvider.java
@@ -2,6 +2,7 @@ package com.sopt.bbangzip.security.jwt;
 
 import com.sopt.bbangzip.common.constants.AuthConstant;
 import com.sopt.bbangzip.domain.token.api.JwtTokensDto;
+import com.sopt.bbangzip.domain.token.api.ReissueJwtTokensDto;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
@@ -44,12 +45,20 @@ public class JwtTokenProvider implements InitializingBean {
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
 
-    // accessToken, RefreshToken 만들어서 반환 !!
+    // accessToken, RefreshToken 만들어서 반환
     public JwtTokensDto issueTokens(final long userId, final boolean isOnboardingComplete) {
         return JwtTokensDto.builder()
                 .accessToken(generateToken(userId, ACCESS_TOKEN_EXPIRE_TIME))
                 .refreshToken(generateToken(userId, REFRESH_TOKEN_EXPIRE_TIME))
                 .isOnboardingComplete(isOnboardingComplete)
+                .build();
+    }
+
+    // 재발급
+    public ReissueJwtTokensDto reissueTokens(final long userId) {
+        return ReissueJwtTokensDto.builder()
+                .accessToken(generateToken(userId, ACCESS_TOKEN_EXPIRE_TIME))
+                .refreshToken(generateToken(userId, REFRESH_TOKEN_EXPIRE_TIME))
                 .build();
     }
 

--- a/src/main/java/com/sopt/bbangzip/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sopt/bbangzip/security/jwt/JwtTokenProvider.java
@@ -1,6 +1,8 @@
 package com.sopt.bbangzip.security.jwt;
 
 import com.sopt.bbangzip.common.constants.AuthConstant;
+import com.sopt.bbangzip.common.exception.base.NotFoundException;
+import com.sopt.bbangzip.common.exception.code.ErrorCode;
 import com.sopt.bbangzip.domain.token.api.JwtTokensDto;
 import com.sopt.bbangzip.domain.token.api.ReissueJwtTokensDto;
 import io.jsonwebtoken.*;
@@ -48,8 +50,8 @@ public class JwtTokenProvider implements InitializingBean {
     // accessToken, RefreshToken 만들어서 반환
     public JwtTokensDto issueTokens(final long userId, final boolean isOnboardingComplete) {
         return JwtTokensDto.builder()
-                .accessToken(generateToken(userId, ACCESS_TOKEN_EXPIRE_TIME))
-                .refreshToken(generateToken(userId, REFRESH_TOKEN_EXPIRE_TIME))
+                .accessToken(generateToken(userId, ACCESS_TOKEN_EXPIRE_TIME, "ACCESS_TOKEN"))
+                .refreshToken(generateToken(userId, REFRESH_TOKEN_EXPIRE_TIME, "REFRESH_TOKEN"))
                 .isOnboardingComplete(isOnboardingComplete)
                 .build();
     }
@@ -57,21 +59,41 @@ public class JwtTokenProvider implements InitializingBean {
     // 재발급
     public ReissueJwtTokensDto reissueTokens(final long userId) {
         return ReissueJwtTokensDto.builder()
-                .accessToken(generateToken(userId, ACCESS_TOKEN_EXPIRE_TIME))
-                .refreshToken(generateToken(userId, REFRESH_TOKEN_EXPIRE_TIME))
+                .accessToken(generateToken(userId, ACCESS_TOKEN_EXPIRE_TIME, "ACCESS_TOKEN"))
+                .refreshToken(generateToken(userId, REFRESH_TOKEN_EXPIRE_TIME, "REFRESH_TOKEN"))
                 .build();
     }
 
+    public void validateRefreshToken(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            // 토큰 타입이 REFRESH_TOKEN인지 확인
+            String tokenType = claims.get("type", String.class);
+            if (!"REFRESH_TOKEN".equals(tokenType)) {
+                throw new NotFoundException(ErrorCode.TYPE_ERROR_JWT_TOKEN);
+            }
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new NotFoundException(ErrorCode.EXPIRED_REFRESH_TOKEN);
+        }
+    }
+
     // JWT 토큰 생성
-    public String generateToken(final long userId, final long tokenExpirationTime) {
+    public String generateToken(final long userId, final long tokenExpirationTime, final String tokenType) {
         final Date now = new Date(System.currentTimeMillis());
-        final Date expirationTime = new Date(System.currentTimeMillis()+tokenExpirationTime);
+        final Date expirationTime = new Date(System.currentTimeMillis() + tokenExpirationTime);
 
         final Claims claims = Jwts.claims()
-                .setIssuedAt(now) // 토큰 발행 시간을 지금으로
-                .setExpiration(expirationTime); // 토큰 만료 시간
+                .setIssuedAt(now) // 토큰 발행 시간
+                .setExpiration(expirationTime) // 토큰 만료 시간
+                .setSubject(tokenType); // 토큰 타입 설정
 
-        claims.put(AuthConstant.USER_ID_CLAIM_NAME, userId);
+        claims.put(AuthConstant.USER_ID_CLAIM_NAME, userId); // 사용자 ID 추가
+        claims.put("type", tokenType); // "type" 클레임 추가
 
         return Jwts.builder()
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE)


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #26 

## Work Description ✏️
<!-- 작업 내용을 간단히 소개주세요 -->
사용자의 refreshToken 을 사용하여 accessToken 을 재발급하는 로직을 구현했습니다.

소셜 로그인 한 다음,
<img width="853" alt="image" src="https://github.com/user-attachments/assets/57a834e8-b1b3-4e8d-9d58-e8b7c5c56db5" />

사용자의 엑세스 토큰으로 요청을 보내면 리프레시 토큰이 아니므로 재발급되지 않습니다.
<img width="858" alt="image" src="https://github.com/user-attachments/assets/1930ecf0-ac24-4317-b75f-64fb94301b94" />


사용자의 리프레시 토큰으로 요청을 보내면 accessToken 과 refreshToken 이 재발급 된 것을 확인하실 수 있습니다.
<img width="849" alt="image" src="https://github.com/user-attachments/assets/de152786-2473-4d35-bea1-c2c9ab17f2e2" />

이 때, 재발급에 사용했던 리프레시 토큰은 폐기하고 다음 요청에서 사용하지 못하도록 구현했습니다.
이 전에 사용했던 리프레시 토큰으로 다시 한 번 더 재발급 요청을 보낼 경우, 아래와 같은 에러가 뜹니다.
<img width="848" alt="image" src="https://github.com/user-attachments/assets/a32779f5-f1c7-4c2a-867b-c44e036a2dff" />

재발급 받았던 refreshToken 으로 다시 한 번 재발급 요청을 보내면 다시 재발급 되는 것을 확인하실 수 있습니다!
<img width="849" alt="image" src="https://github.com/user-attachments/assets/87293714-5fec-43cb-9fbc-8fe913ac7919" />


## Trouble Shooting ⚽️
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->
postman 에서 url 경로 적을 때 앞에 localhost:8080 을 꼭 붙이도록 합시다.. 

## To Reviewers 📢
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
궁금한거 있음 물어봐주세용
