### PR TITLE
:sparkles: [feat] #36 온보딩 완료 API 구현

### DIFF
--- a/src/main/java/com/sopt/bbangzip/domain/auth/AuthController.java
+++ b/src/main/java/com/sopt/bbangzip/domain/auth/AuthController.java
@@ -9,6 +9,7 @@ import com.sopt.bbangzip.domain.token.api.ReissueJwtTokensDto;
 import com.sopt.bbangzip.security.jwt.JwtTokenProvider;
 import jakarta.servlet.http.HttpServletRequest;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -25,7 +26,7 @@ public class AuthController {
     @PostMapping("/user/auth/signin")
     public ResponseEntity<JwtTokensDto> kakaoLogin(
             @RequestParam final String code
-    ){
+    ) {
         return ResponseEntity.ok(authService.kakaoLogin(code));
     }
 
@@ -34,7 +35,7 @@ public class AuthController {
     public ResponseEntity<ReissueJwtTokensDto> reissueToken(
             @UserId final long userId,
             HttpServletRequest request
-    ){
+    ) {
         String refreshToken = jwtTokenProvider.getJwtFromRequest(request);
         if (refreshToken == null) {
             throw new NotFoundException(ErrorCode.INVALID_TOKEN);
@@ -46,8 +47,7 @@ public class AuthController {
     @DeleteMapping("/user/auth/siginout")
     public ResponseEntity<Void> logout(
             @UserId final long userId
-    )
-    {
+    ) {
         authService.logout(userId);
         return ResponseEntity.noContent().build();
     }
@@ -56,8 +56,18 @@ public class AuthController {
     @DeleteMapping("/user/auth/withdraw")
     public ResponseEntity<Void> withdraw(
             @UserId final long userId
-    ){
+    ) {
         authService.withdraw(userId);
-        return  ResponseEntity.noContent().build();
+        return ResponseEntity.noContent().build();
+    }
+
+    // 온보딩 완료 API
+    @PatchMapping("/user/auth/signup")
+    public ResponseEntity<Void> onboarding(
+            @UserId final long userId,
+            @RequestBody @Valid final OnboardingRequestDto onboardingRequestDto
+    ) {
+        authService.onboarding(userId, onboardingRequestDto);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/auth/OnboardingRequestDto.java
+++ b/src/main/java/com/sopt/bbangzip/domain/auth/OnboardingRequestDto.java
@@ -1,0 +1,16 @@
+package com.sopt.bbangzip.domain.auth;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record OnboardingRequestDto(
+        @NotBlank
+        String nickname,
+        @NotNull
+        int year,
+        @NotBlank
+        String semester,
+        @NotBlank
+        String subjectName
+) {
+}

--- a/src/main/java/com/sopt/bbangzip/domain/subject/api/dto/request/SubjectCreateDto.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/api/dto/request/SubjectCreateDto.java
@@ -2,7 +2,9 @@ package com.sopt.bbangzip.domain.subject.api.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 
+@Builder
 public record SubjectCreateDto(
         @NotNull int year, // 년도
         @NotBlank String semester, // 학기 (1, 2 등)

--- a/src/main/java/com/sopt/bbangzip/domain/user/entity/User.java
+++ b/src/main/java/com/sopt/bbangzip/domain/user/entity/User.java
@@ -56,4 +56,13 @@ public class User {
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
     }
+
+    public void updateUser(String nickname, Boolean isOnboardingComplete) {
+        if (nickname != null && !nickname.isEmpty()) {
+            this.nickname = nickname;
+        }
+        if(isOnboardingComplete != null) {
+            this.isOnboardingComplete = isOnboardingComplete;
+        }
+    }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/user/service/UserUpdater.java
+++ b/src/main/java/com/sopt/bbangzip/domain/user/service/UserUpdater.java
@@ -1,0 +1,19 @@
+package com.sopt.bbangzip.domain.user.service;
+
+import com.sopt.bbangzip.domain.auth.OnboardingRequestDto;
+import com.sopt.bbangzip.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserUpdater {
+
+    // 온보딩 완료 시점에 User 정보 수정하는 API
+    public void registerUser(
+            final User user,
+            final OnboardingRequestDto onboardingRequestDto
+    ){
+        user.updateUser(onboardingRequestDto.nickname(), true);
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #38 

## Work Description ✏️
<!-- 작업 내용을 간단히 소개주세요 -->
- 온보딩 완료 후 유저의 nickname 을 등록하고, 온보딩 여부를 true 로 바꿉니다.
- 유저가 선택한 년도와 학기에 과목을 등록합니다.

&nbsp;

소셜 로그인 직후 화면입니다.
![image](https://github.com/user-attachments/assets/ec196838-0de0-4684-b486-c380887dc8a3)

&nbsp;

요청을 보낸 후 유저의 닉네임과 온보딩 여부가 update 된 것을 확인하실 수 있습니다.
![image](https://github.com/user-attachments/assets/866551f6-25d4-4d63-bad4-52b37a07c3dd)
![image](https://github.com/user-attachments/assets/463c662f-d3c7-4a25-b3f3-8378ecb1626a)

&nbsp;

과목도 추가된 것을 확인하실 수 있습니다.
![image](https://github.com/user-attachments/assets/ed987b6c-fca4-44be-a7d1-203d5f88ba4c)
![image](https://github.com/user-attachments/assets/ed17ad78-421a-48a5-8c39-7a79e5300753)




## To Reviewers 📢
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
온보딩 끝 !