### PR TITLE
✨ [feat] #43 공부 조각(교재) 추가하기 API 구현

### DIFF
--- a/src/main/java/com/sopt/bbangzip/common/exception/code/ErrorCode.java
+++ b/src/main/java/com/sopt/bbangzip/common/exception/code/ErrorCode.java
@@ -34,6 +34,8 @@ public enum ErrorCode implements BbangzipErrorCode{
     NOT_FOUND_USER_SUBJECT(HttpStatus.NOT_FOUND,"error","해당 학기에 유저가 등록한 과목이 없습니다"),
     NOT_FOUND_SUBJECT(HttpStatus.NOT_FOUND, "error", "존재하지 않는 과목입니다."),
     NOT_FOUND_TOKEN(HttpStatus.NOT_FOUND, "error", "존재하지 않는 토큰입니다"),
+    NOT_FOUND_STUDY(HttpStatus.NOT_FOUND, "error", "존재하지 않는 공부범위(교재)입니다"),
+    NOT_FOUND_EXAM(HttpStatus.NOT_FOUND, "error", "존재하지 않는 시험입니다."),
 
     // 500
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "error", "서버 내부 오류입니다."),

--- a/src/main/java/com/sopt/bbangzip/domain/exam/api/controller/ExamController.java
+++ b/src/main/java/com/sopt/bbangzip/domain/exam/api/controller/ExamController.java
@@ -8,4 +8,5 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class ExamController {
+
 }

--- a/src/main/java/com/sopt/bbangzip/domain/exam/entity/Exam.java
+++ b/src/main/java/com/sopt/bbangzip/domain/exam/entity/Exam.java
@@ -4,11 +4,14 @@ import com.sopt.bbangzip.common.constants.entity.ExamTableConstants;
 import com.sopt.bbangzip.domain.subject.entity.Subject;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
 @Table(name = ExamTableConstants.TABLE_EXAM)
 @NoArgsConstructor(access= AccessLevel.PROTECTED)
 public class Exam {
@@ -26,9 +29,16 @@ public class Exam {
     private String examName;
 
     @Column(name = ExamTableConstants.COLUMN_EXAM_DATE)
-    private LocalDateTime examDate;
+    private LocalDate examDate;
 
     @Column(name = ExamTableConstants.COLUMN_CREATED_AT, nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    public Exam(Subject subject, String examName, LocalDate examDate) {
+        this.subject = subject;
+        this.examName = examName;
+        this.examDate = examDate;
+        this.createdAt = LocalDateTime.now();
+    }
 
 }

--- a/src/main/java/com/sopt/bbangzip/domain/exam/entity/Exam.java
+++ b/src/main/java/com/sopt/bbangzip/domain/exam/entity/Exam.java
@@ -4,6 +4,7 @@ import com.sopt.bbangzip.common.constants.entity.ExamTableConstants;
 import com.sopt.bbangzip.domain.subject.entity.Subject;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -34,6 +35,7 @@ public class Exam {
     @Column(name = ExamTableConstants.COLUMN_CREATED_AT, nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    @Builder
     public Exam(Subject subject, String examName, LocalDate examDate) {
         this.subject = subject;
         this.examName = examName;

--- a/src/main/java/com/sopt/bbangzip/domain/exam/repository/ExamRepository.java
+++ b/src/main/java/com/sopt/bbangzip/domain/exam/repository/ExamRepository.java
@@ -2,8 +2,20 @@ package com.sopt.bbangzip.domain.exam.repository;
 
 import com.sopt.bbangzip.domain.exam.entity.Exam;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ExamRepository extends JpaRepository<Exam, Long> {
+    @Query("SELECT e FROM Exam e WHERE e.subject.id = :subjectId AND e.examName = :examName AND e.examDate = :examDate")
+    Optional<Exam> findBySubjectIdAndExamNameAndExamDate(@Param("subjectId") Long subjectId,
+                                                         @Param("examName") String examName,
+                                                         @Param("examDate") LocalDate examDate);
+
 }

--- a/src/main/java/com/sopt/bbangzip/domain/exam/service/ExamRetriever.java
+++ b/src/main/java/com/sopt/bbangzip/domain/exam/service/ExamRetriever.java
@@ -10,15 +10,20 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
 public class ExamRetriever {
     private final ExamRepository examRepository;
 
-    public Exam findBySubjectIdAndExamNameAndExamDate(Long subjectId, String examName, LocalDate examDate) {
-        return examRepository.findBySubjectIdAndExamNameAndExamDate(subjectId, examName, examDate)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_EXAM));
+    //    public Exam findBySubjectIdAndExamNameAndExamDate(Long subjectId, String examName, LocalDate examDate) {
+//        return examRepository.findBySubjectIdAndExamNameAndExamDate(subjectId, examName, examDate)
+//                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_EXAM));
+//    }
+    public Optional<Exam> findBySubjectIdAndExamNameAndExamDate(Long subjectId, String examName, LocalDate examDate) {
+        return examRepository.findBySubjectIdAndExamNameAndExamDate(subjectId, examName, examDate);
     }
+
 }
 

--- a/src/main/java/com/sopt/bbangzip/domain/exam/service/ExamRetriever.java
+++ b/src/main/java/com/sopt/bbangzip/domain/exam/service/ExamRetriever.java
@@ -1,0 +1,24 @@
+package com.sopt.bbangzip.domain.exam.service;
+
+import com.sopt.bbangzip.common.exception.base.NotFoundException;
+import com.sopt.bbangzip.common.exception.code.ErrorCode;
+import com.sopt.bbangzip.domain.exam.entity.Exam;
+import com.sopt.bbangzip.domain.exam.repository.ExamRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class ExamRetriever {
+    private final ExamRepository examRepository;
+
+    public Exam findBySubjectIdAndExamNameAndExamDate(Long subjectId, String examName, LocalDate examDate) {
+        return examRepository.findBySubjectIdAndExamNameAndExamDate(subjectId, examName, examDate)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_EXAM));
+    }
+}
+

--- a/src/main/java/com/sopt/bbangzip/domain/exam/service/ExamRetriever.java
+++ b/src/main/java/com/sopt/bbangzip/domain/exam/service/ExamRetriever.java
@@ -17,13 +17,9 @@ import java.util.Optional;
 public class ExamRetriever {
     private final ExamRepository examRepository;
 
-    //    public Exam findBySubjectIdAndExamNameAndExamDate(Long subjectId, String examName, LocalDate examDate) {
-//        return examRepository.findBySubjectIdAndExamNameAndExamDate(subjectId, examName, examDate)
-//                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_EXAM));
-//    }
-    public Optional<Exam> findBySubjectIdAndExamNameAndExamDate(Long subjectId, String examName, LocalDate examDate) {
-        return examRepository.findBySubjectIdAndExamNameAndExamDate(subjectId, examName, examDate);
+        public Exam findBySubjectIdAndExamNameAndExamDate(Long subjectId, String examName, LocalDate examDate) {
+        return examRepository.findBySubjectIdAndExamNameAndExamDate(subjectId, examName, examDate)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_EXAM));
     }
-
 }
 

--- a/src/main/java/com/sopt/bbangzip/domain/exam/service/ExamSaver.java
+++ b/src/main/java/com/sopt/bbangzip/domain/exam/service/ExamSaver.java
@@ -5,6 +5,7 @@ import com.sopt.bbangzip.domain.exam.repository.ExamRepository;
 import com.sopt.bbangzip.domain.subject.entity.Subject;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 
@@ -12,16 +13,22 @@ import java.time.LocalDate;
 @RequiredArgsConstructor
 public class ExamSaver {
     private final ExamRepository examRepository;
-    private final ExamRetriever examRetriever;
 
-    public Exam saveExam(Subject subject, String examName, LocalDate examDate) {
-        try {
-            // ExamRetriever를 사용하여 Exam 조회
-            return examRetriever.findBySubjectIdAndExamNameAndExamDate(subject.getId(), examName, examDate);
-        } catch (Exception e) {
-            // Exam이 없을 경우 새로 생성 후 저장
-            return examRepository.save(new Exam(subject, examName, examDate));
-        }
+    // 시험 저장
+    @Transactional
+    public void save(final Exam exam) {
+        examRepository.save(exam);
+    }
+
+    // Exam 객체 생성 및 저장
+    @Transactional
+    public Exam createAndSaveExam(Subject subject, String examName, LocalDate examDate) {
+        Exam newExam = Exam.builder()
+                .subject(subject)
+                .examName(examName)
+                .examDate(examDate)
+                .build();
+        return examRepository.save(newExam);
     }
 }
 

--- a/src/main/java/com/sopt/bbangzip/domain/exam/service/ExamSaver.java
+++ b/src/main/java/com/sopt/bbangzip/domain/exam/service/ExamSaver.java
@@ -2,33 +2,17 @@ package com.sopt.bbangzip.domain.exam.service;
 
 import com.sopt.bbangzip.domain.exam.entity.Exam;
 import com.sopt.bbangzip.domain.exam.repository.ExamRepository;
-import com.sopt.bbangzip.domain.subject.entity.Subject;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 
 @Component
 @RequiredArgsConstructor
 public class ExamSaver {
     private final ExamRepository examRepository;
 
-    // 시험 저장
-    @Transactional
-    public void save(final Exam exam) {
-        examRepository.save(exam);
-    }
-
-    // Exam 객체 생성 및 저장
-    @Transactional
-    public Exam createAndSaveExam(Subject subject, String examName, LocalDate examDate) {
-        Exam newExam = Exam.builder()
-                .subject(subject)
-                .examName(examName)
-                .examDate(examDate)
-                .build();
-        return examRepository.save(newExam);
+    public Exam save(Exam exam) {
+        return examRepository.save(exam);
     }
 }
 

--- a/src/main/java/com/sopt/bbangzip/domain/exam/service/ExamSaver.java
+++ b/src/main/java/com/sopt/bbangzip/domain/exam/service/ExamSaver.java
@@ -1,0 +1,27 @@
+package com.sopt.bbangzip.domain.exam.service;
+
+import com.sopt.bbangzip.domain.exam.entity.Exam;
+import com.sopt.bbangzip.domain.exam.repository.ExamRepository;
+import com.sopt.bbangzip.domain.subject.entity.Subject;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+@RequiredArgsConstructor
+public class ExamSaver {
+    private final ExamRepository examRepository;
+    private final ExamRetriever examRetriever;
+
+    public Exam saveExam(Subject subject, String examName, LocalDate examDate) {
+        try {
+            // ExamRetriever를 사용하여 Exam 조회
+            return examRetriever.findBySubjectIdAndExamNameAndExamDate(subject.getId(), examName, examDate);
+        } catch (Exception e) {
+            // Exam이 없을 경우 새로 생성 후 저장
+            return examRepository.save(new Exam(subject, examName, examDate));
+        }
+    }
+}
+

--- a/src/main/java/com/sopt/bbangzip/domain/exam/service/ExamService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/exam/service/ExamService.java
@@ -12,12 +12,5 @@ import java.time.LocalDate;
 @Service
 @RequiredArgsConstructor
 public class ExamService {
-    private final ExamRetriever examRetriever;
-    private final ExamSaver examSaver;
-
-    public Exam findOrCreateExam(Subject subject, String examName, LocalDate examDate) {
-        return examRetriever.findBySubjectIdAndExamNameAndExamDate(subject.getId(), examName, examDate)
-                .orElseGet(() -> examSaver.createAndSaveExam(subject, examName, examDate));
-    }
 }
 

--- a/src/main/java/com/sopt/bbangzip/domain/exam/service/ExamService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/exam/service/ExamService.java
@@ -1,11 +1,23 @@
 package com.sopt.bbangzip.domain.exam.service;
 
+import com.sopt.bbangzip.domain.exam.entity.Exam;
+import com.sopt.bbangzip.domain.subject.entity.Subject;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ExamService {
+    private final ExamRetriever examRetriever;
+    private final ExamSaver examSaver;
+
+    public Exam findOrCreateExam(Subject subject, String examName, LocalDate examDate) {
+        return examRetriever.findBySubjectIdAndExamNameAndExamDate(subject.getId(), examName, examDate)
+                .orElseGet(() -> examSaver.createAndSaveExam(subject, examName, examDate));
+    }
 }
+

--- a/src/main/java/com/sopt/bbangzip/domain/piece/entity/Piece.java
+++ b/src/main/java/com/sopt/bbangzip/domain/piece/entity/Piece.java
@@ -42,10 +42,10 @@ public class Piece {
     private Boolean isFinished = false;
 
     @Column(name = PieceTableConstants.COLUMN_IS_VISIBLE, nullable = false)
-    private Boolean isVisible = true;
+    private Boolean isVisible = false;
 
     @Column(name = PieceTableConstants.COLUMN_PAGE_AMOUNT)
-    private Integer pageAmount;
+    private int pageAmount;
 
     @Column(name = PieceTableConstants.COLUMN_CREATED_AT, nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/sopt/bbangzip/domain/piece/entity/Piece.java
+++ b/src/main/java/com/sopt/bbangzip/domain/piece/entity/Piece.java
@@ -4,11 +4,15 @@ import com.sopt.bbangzip.common.constants.entity.PieceTableConstants;
 import com.sopt.bbangzip.domain.study.entity.Study;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @Entity
+@Getter
 @Table(name = PieceTableConstants.TABLE_PIECE)
 @NoArgsConstructor(access= AccessLevel.PROTECTED)
 public class Piece {
@@ -23,22 +27,22 @@ public class Piece {
     private Study study;
 
     @Column(name = PieceTableConstants.COLUMN_PIECE_NUMBER, nullable = false)
-    private Integer pieceNumber;
+    private int pieceNumber;
 
     @Column(name = PieceTableConstants.COLUMN_START_PAGE, nullable = false)
-    private Integer startPage;
+    private int startPage;
 
     @Column(name = PieceTableConstants.COLUMN_FINISH_PAGE, nullable = false)
-    private Integer finishPage;
+    private int finishPage;
 
     @Column(name = PieceTableConstants.COLUMN_DEADLINE)
-    private LocalDateTime deadline;
+    private LocalDate deadline;
 
     @Column(name = PieceTableConstants.COLUMN_IS_FINISHED, nullable = false)
-    private Boolean isFinished;
+    private Boolean isFinished = false;
 
     @Column(name = PieceTableConstants.COLUMN_IS_VISIBLE, nullable = false)
-    private Boolean isVisible;
+    private Boolean isVisible = true;
 
     @Column(name = PieceTableConstants.COLUMN_PAGE_AMOUNT)
     private Integer pageAmount;
@@ -49,4 +53,18 @@ public class Piece {
     @Column(name = PieceTableConstants.COLUMN_UPDATED_AT)
     private LocalDateTime updatedAt;
 
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy년MM월dd일");
+
+    public Piece(Study study, int startPage, int finishPage, String deadline) {
+        this.study = study;
+        this.startPage = startPage;
+        this.finishPage = finishPage;
+        this.deadline = parseStringToLocalDate(deadline);
+        this.createdAt = LocalDateTime.now();
+    }
+
+    // String 값을 LocalDate로 변환
+    private LocalDate parseStringToLocalDate(String date) {
+        return LocalDate.parse(date, DATE_FORMATTER);
+    }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/piece/entity/Piece.java
+++ b/src/main/java/com/sopt/bbangzip/domain/piece/entity/Piece.java
@@ -4,6 +4,7 @@ import com.sopt.bbangzip.common.constants.entity.PieceTableConstants;
 import com.sopt.bbangzip.domain.study.entity.Study;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -55,12 +56,15 @@ public class Piece {
 
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy년MM월dd일");
 
+    @Builder
     public Piece(Study study, int startPage, int finishPage, String deadline) {
         this.study = study;
         this.startPage = startPage;
         this.finishPage = finishPage;
+        this.pageAmount = finishPage - startPage + 1;
         this.deadline = parseStringToLocalDate(deadline);
         this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
     }
 
     // String 값을 LocalDate로 변환

--- a/src/main/java/com/sopt/bbangzip/domain/piece/service/PieceSaver.java
+++ b/src/main/java/com/sopt/bbangzip/domain/piece/service/PieceSaver.java
@@ -2,13 +2,10 @@ package com.sopt.bbangzip.domain.piece.service;
 
 import com.sopt.bbangzip.domain.piece.entity.Piece;
 import com.sopt.bbangzip.domain.piece.repository.PieceRepository;
-import com.sopt.bbangzip.domain.study.entity.Study;
-import com.sopt.bbangzip.domain.study.api.dto.request.StudyCreateRequestDto.PieceRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -16,15 +13,7 @@ public class PieceSaver {
 
     private final PieceRepository pieceRepository;
 
-    public List<Piece> savePieces(Study study, List<PieceRequestDto> pieceRequestDtos) {
-        List<Piece> pieces = pieceRequestDtos.stream()
-                .map(pieceDto -> new Piece(
-                        study,
-                        pieceDto.startPage(),
-                        pieceDto.finishPage(),
-                        pieceDto.deadline()
-                ))
-                .collect(Collectors.toList());
+    public List<Piece> saveAll(List<Piece> pieces) {
         return pieceRepository.saveAll(pieces);
     }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/piece/service/PieceSaver.java
+++ b/src/main/java/com/sopt/bbangzip/domain/piece/service/PieceSaver.java
@@ -1,0 +1,30 @@
+package com.sopt.bbangzip.domain.piece.service;
+
+import com.sopt.bbangzip.domain.piece.entity.Piece;
+import com.sopt.bbangzip.domain.piece.repository.PieceRepository;
+import com.sopt.bbangzip.domain.study.entity.Study;
+import com.sopt.bbangzip.domain.study.api.dto.request.StudyCreateRequestDto.PieceRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class PieceSaver {
+
+    private final PieceRepository pieceRepository;
+
+    public List<Piece> savePieces(Study study, List<PieceRequestDto> pieceRequestDtos) {
+        List<Piece> pieces = pieceRequestDtos.stream()
+                .map(pieceDto -> new Piece(
+                        study,
+                        pieceDto.startPage(),
+                        pieceDto.finishPage(),
+                        pieceDto.deadline()
+                ))
+                .collect(Collectors.toList());
+        return pieceRepository.saveAll(pieces);
+    }
+}

--- a/src/main/java/com/sopt/bbangzip/domain/piece/service/PieceService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/piece/service/PieceService.java
@@ -1,9 +1,31 @@
 package com.sopt.bbangzip.domain.piece.service;
 
+import com.sopt.bbangzip.domain.piece.entity.Piece;
+import com.sopt.bbangzip.domain.study.entity.Study;
+import com.sopt.bbangzip.domain.study.api.dto.request.StudyCreateRequestDto.PieceRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class PieceService {
+
+    private final PieceSaver pieceSaver;
+
+    // Piece 생성 및 저장
+    public List<Piece> createAndSavePieces(Study study, List<PieceRequestDto> pieceRequestDtos) {
+        List<Piece> pieces = pieceRequestDtos.stream()
+                .map(pieceDto -> Piece.builder()
+                        .study(study)
+                        .startPage(pieceDto.startPage())
+                        .finishPage(pieceDto.finishPage())
+                        .deadline(pieceDto.deadline())
+                        .build()
+                )
+                .collect(Collectors.toList());
+        return pieceSaver.saveAll(pieces);
+    }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/piece/service/PieceService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/piece/service/PieceService.java
@@ -1,10 +1,8 @@
 package com.sopt.bbangzip.domain.piece.service;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PieceService {

--- a/src/main/java/com/sopt/bbangzip/domain/study/api/controller/StudyController.java
+++ b/src/main/java/com/sopt/bbangzip/domain/study/api/controller/StudyController.java
@@ -1,11 +1,13 @@
 package com.sopt.bbangzip.domain.study.api.controller;
 
 import com.sopt.bbangzip.common.annotation.UserId;
+import com.sopt.bbangzip.common.dto.ResponseDto;
 import com.sopt.bbangzip.domain.study.api.dto.request.StudyCreateRequestDto;
 import com.sopt.bbangzip.domain.study.api.dto.response.StudyCreateResponseDto;
 import com.sopt.bbangzip.domain.study.service.StudyService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,11 +21,11 @@ public class StudyController {
     private final StudyService studyService;
 
     @PostMapping("/studies")
-    public ResponseEntity<?> createStudy(
+    public ResponseEntity<ResponseDto<StudyCreateResponseDto>> createStudy(
             @UserId final Long userId,
             @RequestBody @Valid final StudyCreateRequestDto studyCreateRequestDto
     ) {
         StudyCreateResponseDto responseDto = studyService.createStudy(userId, studyCreateRequestDto);
-        return ResponseEntity.ok(responseDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ResponseDto.success(responseDto));
     }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/study/api/controller/StudyController.java
+++ b/src/main/java/com/sopt/bbangzip/domain/study/api/controller/StudyController.java
@@ -21,11 +21,11 @@ public class StudyController {
     private final StudyService studyService;
 
     @PostMapping("/studies")
-    public ResponseEntity<ResponseDto<StudyCreateResponseDto>> createStudy(
+    public ResponseEntity<StudyCreateResponseDto> createStudy(
             @UserId final Long userId,
             @RequestBody @Valid final StudyCreateRequestDto studyCreateRequestDto
     ) {
         StudyCreateResponseDto responseDto = studyService.createStudy(userId, studyCreateRequestDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(ResponseDto.success(responseDto));
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/study/api/controller/StudyController.java
+++ b/src/main/java/com/sopt/bbangzip/domain/study/api/controller/StudyController.java
@@ -1,6 +1,14 @@
 package com.sopt.bbangzip.domain.study.api.controller;
 
+import com.sopt.bbangzip.common.annotation.UserId;
+import com.sopt.bbangzip.domain.study.api.dto.request.StudyCreateRequestDto;
+import com.sopt.bbangzip.domain.study.api.dto.response.StudyCreateResponseDto;
+import com.sopt.bbangzip.domain.study.service.StudyService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -8,4 +16,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class StudyController {
+    private final StudyService studyService;
+
+    @PostMapping("/studies")
+    public ResponseEntity<?> createStudy(
+            @UserId final Long userId,
+            @RequestBody @Valid final StudyCreateRequestDto studyCreateRequestDto
+    ) {
+        StudyCreateResponseDto responseDto = studyService.createStudy(userId, studyCreateRequestDto);
+        return ResponseEntity.ok(responseDto);
+    }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/study/api/dto/request/StudyCreateRequestDto.java
+++ b/src/main/java/com/sopt/bbangzip/domain/study/api/dto/request/StudyCreateRequestDto.java
@@ -1,0 +1,25 @@
+package com.sopt.bbangzip.domain.study.api.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record StudyCreateRequestDto(
+        @NotNull Long subjectId,
+        @NotBlank String subjectName,
+        @NotBlank String examName,
+        @NotNull String examDate,
+        @NotBlank String studyContents,
+        @NotEmpty List<PieceRequestDto> pieceList
+) {
+    public record PieceRequestDto(
+            @NotNull int startPage,
+            @NotNull int finishPage,
+            @NotBlank String deadline
+    ) {}
+}
+
+
+

--- a/src/main/java/com/sopt/bbangzip/domain/study/api/dto/response/StudyCreateResponseDto.java
+++ b/src/main/java/com/sopt/bbangzip/domain/study/api/dto/response/StudyCreateResponseDto.java
@@ -1,0 +1,30 @@
+package com.sopt.bbangzip.domain.study.api.dto.response;
+
+import com.sopt.bbangzip.domain.exam.entity.Exam;
+import com.sopt.bbangzip.domain.piece.entity.Piece;
+import com.sopt.bbangzip.domain.study.entity.Study;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public record StudyCreateResponseDto(
+        Long studyId,
+        Long examId,
+        String studyContents,
+        int startPage,
+        int finishPage,
+        String examDate
+) {
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy년MM월dd일");
+
+    public StudyCreateResponseDto(Study study, Exam exam, List<Piece> pieces) {
+        this(
+                study.getId(),
+                exam.getId(),
+                study.getStudyContents(),
+                pieces.stream().mapToInt(Piece::getStartPage).min().orElse(0),
+                pieces.stream().mapToInt(Piece::getFinishPage).max().orElse(0),
+                exam.getExamDate().format(DATE_FORMATTER) // LocalDate -> String 변환
+        );
+    }
+}

--- a/src/main/java/com/sopt/bbangzip/domain/study/api/dto/response/StudyCreateResponseDto.java
+++ b/src/main/java/com/sopt/bbangzip/domain/study/api/dto/response/StudyCreateResponseDto.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
+@Builder
 public record StudyCreateResponseDto(
         Long studyId,
         Long examId,
@@ -17,16 +18,6 @@ public record StudyCreateResponseDto(
         String examDate
 ) {
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy년MM월dd일");
-
-    @Builder
-    public StudyCreateResponseDto(Long studyId, Long examId, String studyContents, int startPage, int finishPage, String examDate) {
-        this.studyId = studyId;
-        this.examId = examId;
-        this.studyContents = studyContents;
-        this.startPage = startPage;
-        this.finishPage = finishPage;
-        this.examDate = examDate;
-    }
 
     public static StudyCreateResponseDto from(Study study, Exam exam, List<Piece> pieces) {
         return StudyCreateResponseDto.builder()

--- a/src/main/java/com/sopt/bbangzip/domain/study/api/dto/response/StudyCreateResponseDto.java
+++ b/src/main/java/com/sopt/bbangzip/domain/study/api/dto/response/StudyCreateResponseDto.java
@@ -3,6 +3,7 @@ package com.sopt.bbangzip.domain.study.api.dto.response;
 import com.sopt.bbangzip.domain.exam.entity.Exam;
 import com.sopt.bbangzip.domain.piece.entity.Piece;
 import com.sopt.bbangzip.domain.study.entity.Study;
+import lombok.Builder;
 
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -17,14 +18,24 @@ public record StudyCreateResponseDto(
 ) {
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy년MM월dd일");
 
-    public StudyCreateResponseDto(Study study, Exam exam, List<Piece> pieces) {
-        this(
-                study.getId(),
-                exam.getId(),
-                study.getStudyContents(),
-                pieces.stream().mapToInt(Piece::getStartPage).min().orElse(0),
-                pieces.stream().mapToInt(Piece::getFinishPage).max().orElse(0),
-                exam.getExamDate().format(DATE_FORMATTER) // LocalDate -> String 변환
-        );
+    @Builder
+    public StudyCreateResponseDto(Long studyId, Long examId, String studyContents, int startPage, int finishPage, String examDate) {
+        this.studyId = studyId;
+        this.examId = examId;
+        this.studyContents = studyContents;
+        this.startPage = startPage;
+        this.finishPage = finishPage;
+        this.examDate = examDate;
+    }
+
+    public static StudyCreateResponseDto from(Study study, Exam exam, List<Piece> pieces) {
+        return StudyCreateResponseDto.builder()
+                .studyId(study.getId())
+                .examId(exam.getId())
+                .studyContents(study.getStudyContents())
+                .startPage(pieces.stream().mapToInt(Piece::getStartPage).min().orElse(0))
+                .finishPage(pieces.stream().mapToInt(Piece::getFinishPage).max().orElse(0))
+                .examDate(exam.getExamDate().format(DATE_FORMATTER))
+                .build();
     }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/study/entity/Study.java
+++ b/src/main/java/com/sopt/bbangzip/domain/study/entity/Study.java
@@ -5,12 +5,14 @@ import com.sopt.bbangzip.domain.exam.entity.Exam;
 import com.sopt.bbangzip.domain.piece.entity.Piece;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
+@Getter
 @Table(name = StudyTableConstants.TABLE_STUDY)
 @NoArgsConstructor(access= AccessLevel.PROTECTED)
 public class Study {
@@ -33,4 +35,9 @@ public class Study {
     @OneToMany(mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Piece> pieces;
 
+    public Study(Exam exam, String studyContents) {
+        this.exam = exam;
+        this.studyContents = studyContents;
+        this.createdAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/study/entity/Study.java
+++ b/src/main/java/com/sopt/bbangzip/domain/study/entity/Study.java
@@ -5,6 +5,7 @@ import com.sopt.bbangzip.domain.exam.entity.Exam;
 import com.sopt.bbangzip.domain.piece.entity.Piece;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -35,6 +36,7 @@ public class Study {
     @OneToMany(mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Piece> pieces;
 
+    @Builder
     public Study(Exam exam, String studyContents) {
         this.exam = exam;
         this.studyContents = studyContents;

--- a/src/main/java/com/sopt/bbangzip/domain/study/repository/StudyRepository.java
+++ b/src/main/java/com/sopt/bbangzip/domain/study/repository/StudyRepository.java
@@ -4,6 +4,8 @@ import com.sopt.bbangzip.domain.study.entity.Study;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface StudyRepository extends JpaRepository<Study, Long> {
 }

--- a/src/main/java/com/sopt/bbangzip/domain/study/service/StudyRetriever.java
+++ b/src/main/java/com/sopt/bbangzip/domain/study/service/StudyRetriever.java
@@ -1,0 +1,9 @@
+package com.sopt.bbangzip.domain.study.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StudyRetriever {
+}

--- a/src/main/java/com/sopt/bbangzip/domain/study/service/StudySaver.java
+++ b/src/main/java/com/sopt/bbangzip/domain/study/service/StudySaver.java
@@ -1,0 +1,22 @@
+package com.sopt.bbangzip.domain.study.service;
+
+import com.sopt.bbangzip.domain.exam.entity.Exam;
+import com.sopt.bbangzip.domain.study.entity.Study;
+import com.sopt.bbangzip.domain.study.repository.StudyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StudySaver {
+
+    private final StudyRepository studyRepository;
+
+    public Study saveStudy(Exam exam, String studyContents) {
+        Study study = new Study(
+                exam,
+                studyContents
+        );
+        return studyRepository.save(study);
+    }
+}

--- a/src/main/java/com/sopt/bbangzip/domain/study/service/StudySaver.java
+++ b/src/main/java/com/sopt/bbangzip/domain/study/service/StudySaver.java
@@ -12,11 +12,7 @@ public class StudySaver {
 
     private final StudyRepository studyRepository;
 
-    public Study saveStudy(Exam exam, String studyContents) {
-        Study study = new Study(
-                exam,
-                studyContents
-        );
+    public Study save(Study study) {
         return studyRepository.save(study);
     }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/study/service/StudyService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/study/service/StudyService.java
@@ -1,11 +1,64 @@
 package com.sopt.bbangzip.domain.study.service;
 
+import com.sopt.bbangzip.domain.exam.entity.Exam;
+import com.sopt.bbangzip.domain.exam.service.ExamSaver;
+import com.sopt.bbangzip.domain.piece.entity.Piece;
+import com.sopt.bbangzip.domain.piece.service.PieceSaver;
+import com.sopt.bbangzip.domain.study.api.dto.request.StudyCreateRequestDto;
+import com.sopt.bbangzip.domain.study.api.dto.response.StudyCreateResponseDto;
+import com.sopt.bbangzip.domain.study.entity.Study;
+import com.sopt.bbangzip.domain.subject.entity.Subject;
+import com.sopt.bbangzip.domain.subject.service.SubjectRetriever;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class StudyService {
+
+    private final PieceSaver pieceSaver;
+    private final ExamSaver examSaver;
+    private final StudySaver studySaver;
+    private final SubjectRetriever subjectRetriever;
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy년MM월dd일");
+
+    @Transactional
+    public StudyCreateResponseDto createStudy(Long userId, StudyCreateRequestDto requestDto) {
+        // 1. 과목 조회
+        Subject subject = subjectRetriever.findByUserIdAndSubjectName(
+                userId,
+                requestDto.subjectId(),
+                requestDto.subjectName()
+        );
+
+        // 2. 시험 저장 또는 가져오기
+        Exam exam = examSaver.saveExam(
+                subject,
+                requestDto.examName(),
+                parseStringToLocalDate(requestDto.examDate())
+        );
+
+        // 3. Study 저장
+        Study study = studySaver.saveStudy(exam, requestDto.studyContents());
+
+        // 4. Piece 저장
+        List<Piece> pieces = pieceSaver.savePieces(study, requestDto.pieceList());
+
+        return new StudyCreateResponseDto(
+                study,
+                exam,
+                pieces
+        );
+    }
+
+    // 날짜 String을 LocalDateTime으로 변환
+    private LocalDate parseStringToLocalDate(String date) {
+        return LocalDate.parse(date, DATE_FORMATTER);
+    }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/study/service/StudyService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/study/service/StudyService.java
@@ -24,9 +24,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class StudyService {
-
     private final PieceSaver pieceSaver;
-    private final ExamRetriever examRetriever;
     private final ExamSaver examSaver;
     private final StudySaver studySaver;
     private final SubjectRetriever subjectRetriever;
@@ -37,7 +35,12 @@ public class StudyService {
     public StudyCreateResponseDto createStudy(Long userId, StudyCreateRequestDto requestDto) {
 
         Subject subject = subjectRetriever.findByUserIdAndSubjectName(userId, requestDto.subjectId(), requestDto.subjectName());
-        Exam exam = examRetriever.findBySubjectIdAndExamNameAndExamDate(subject.getId(), requestDto.examName(), parseStringToLocalDate(requestDto.examDate()));
+
+        Exam exam = Exam.builder()
+                .examName(requestDto.examName())
+                .examDate(parseStringToLocalDate(requestDto.examDate()))
+                .subject(subject)
+                .build();
         examSaver.save(exam);
 
         Study study = Study.builder()

--- a/src/main/java/com/sopt/bbangzip/domain/subject/api/controller/SubjectController.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/api/controller/SubjectController.java
@@ -40,17 +40,16 @@ public class SubjectController {
         return ResponseEntity.noContent().build();
     }
 
-     // 과목명 및 과목 별 동기부여 메세지 작성 및 수정 API
+    // 과목명 및 과목 별 동기부여 메세지 작성 및 수정 API
     @PutMapping("/subjects/{subjectId}/{options}")
     public ResponseEntity<Void> updateMotivationMessage(
             @UserId final Long userId,
             @PathVariable final Long subjectId,
             @PathVariable final String options,
             @RequestBody @Valid final SubjectNameOrMotivationMessageDto subjectNameOrMotivationMessageDto
-            ) {
+    ) {
 
         subjectService.updateSubjectNameOrMotivationMessage(userId, subjectId, options, subjectNameOrMotivationMessageDto.value());
         return ResponseEntity.noContent().build();
     }
-
 }

--- a/src/main/java/com/sopt/bbangzip/domain/subject/api/controller/SubjectController.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/api/controller/SubjectController.java
@@ -43,8 +43,8 @@ public class SubjectController {
     // 과목명 및 과목 별 동기부여 메세지 작성 및 수정 API
     @PutMapping("/subjects/{subjectId}/{options}")
     public ResponseEntity<Void> updateMotivationMessage(
-            @UserId final Long userId,
-            @PathVariable final Long subjectId,
+            @UserId final long userId,
+            @PathVariable final long subjectId,
             @PathVariable final String options,
             @RequestBody @Valid final SubjectNameOrMotivationMessageDto subjectNameOrMotivationMessageDto
     ) {

--- a/src/main/java/com/sopt/bbangzip/domain/subject/repository/SubjectRepository.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/repository/SubjectRepository.java
@@ -11,9 +11,16 @@ import java.util.Optional;
 
 @Repository
 public interface SubjectRepository extends JpaRepository<Subject, Long> {
+
+    //  UserSubject와 SubjectName으로 Subject 존재 여부 확인
     boolean existsByUserSubjectAndSubjectName(UserSubject userSubject, String subjectName);
     // 특정 UserSubject ID와 과목 ID로 과목 조회
     List<Subject> findByIdInAndUserSubjectId(List<Long> subjectIds, Long userSubjectId);
 
     Optional<Subject> findById(Long subjectId);
+
+    // UserSubject와 SubjectName으로 Subject 조회
+    Optional<Subject> findByUserSubjectAndSubjectName(UserSubject userSubject, String subjectName);
+
+    Optional<Subject> findByUserSubject_UserIdAndIdAndSubjectName(Long userId, Long subjectId, String subjectName);
 }

--- a/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectRetriever.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectRetriever.java
@@ -44,4 +44,20 @@ public class SubjectRetriever {
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_SUBJECT));
     }
 
+    // UserId와 SubjectName으로 특정 과목(Subject) 조회
+    public Subject findByUserIdAndSubjectName(Long userId, int year, String semester, String subjectName) {
+        // UserSubject 조회
+        UserSubject userSubject = findByUserIdAndYearAndSemester(userId, year, semester);
+
+        // Subject 조회
+        return subjectRepository.findByUserSubjectAndSubjectName(userSubject, subjectName)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_SUBJECT));
+    }
+
+    // UserId 과목 ID, 과목 이름으로 과목을 조회하는 메서드
+    public Subject findByUserIdAndSubjectName(Long userId, Long subjectId, String subjectName) {
+        return subjectRepository.findByUserSubject_UserIdAndIdAndSubjectName(userId, subjectId, subjectName)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_SUBJECT));
+    }
+
 }

--- a/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectService.java
@@ -81,5 +81,4 @@ public class SubjectService {
             default -> throw new InvalidOptionsException(ErrorCode.INVALID_OPTION);
         }
     }
-
 }

--- a/src/main/java/com/sopt/bbangzip/domain/userSubject/repository/UserSubjectRepository.java
+++ b/src/main/java/com/sopt/bbangzip/domain/userSubject/repository/UserSubjectRepository.java
@@ -4,6 +4,7 @@ import com.sopt.bbangzip.domain.userSubject.entity.UserSubject;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -14,5 +15,6 @@ public interface UserSubjectRepository extends JpaRepository<UserSubject, Long> 
 
     // userId와 userSubjectId로 UserSubject 조회
     Optional<UserSubject> findByUserIdAndId(Long userId, Long userSubjectId);
+
 }
 


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #43 

## Work Description ✏️

과목 속에 시험과 연계된 공부 범위를 추가합니다.

과목정보, 시험 일자, 공부 내용, 시작 페이지, 종료 페이지를 포함한 데이터를 저장합니다.

- [ ] 사용자의 과목 조회
- [ ] 시험 등록 (시험 이름 및 시험 날짜)
- [ ] 교재가 등록됨 -> Piece로 ~

![image](https://github.com/user-attachments/assets/b38c09b3-4e20-4334-b741-8de8f9b48150)

시험이 등록됩니다.
![image](https://github.com/user-attachments/assets/b123bf38-1667-4d75-b47b-deb9866717a8)

교재가 등록됩니다.
![image](https://github.com/user-attachments/assets/a43c6a21-e61a-4d66-ae49-a0f6ec8c8ccb)

조각이 등록됩니다.
![image](https://github.com/user-attachments/assets/5fc7815e-d524-4193-b561-ce4ecc711760)

## Trouble Shooting ⚽️
```
   @Column(name = PieceTableConstants.COLUMN_DEADLINE)
    private LocalDate deadline;

    @Column(name = PieceTableConstants.COLUMN_IS_FINISHED, nullable = false)
    private Boolean isFinished = false;

    @Column(name = PieceTableConstants.COLUMN_IS_VISIBLE, nullable = false)
    private Boolean isVisible = false;
``` 
`isFinished` 와 `isVisible`을 초기값 설정을 했고, 날짜 관련 정보도 `LocalDateTime` 에서`LocalDate`로 변경했습니다.

## To Reviewers 📢

`Exam` , `Subject`, `Study`, `Piece` 등 모든 관련 데이터를 다루다보니 서비스에서의 역할분리가 잘 이루어졌는지 헷갈리는데 해당 사항 중점적으로 봐주시면 좋을 것 같아요 !
추가적으로 수정사항 있다면 편하게 말해주세요
