### PR TITLE
✏️ [fix] #55 공부 조각 완료 체크하기 API 뱃지 획득 로직 수정

### DIFF
--- a/src/main/java/com/sopt/bbangzip/common/constants/entity/UserTableConstants.java
+++ b/src/main/java/com/sopt/bbangzip/common/constants/entity/UserTableConstants.java
@@ -11,8 +11,8 @@ public class UserTableConstants {
     public static final String COLUMN_USER_LEVEL = "user_level";
     public static final String COLUMN_CREATED_AT = "created_at";
     public static final String COLUMN_UPDATED_AT = "updated_at";
-    public static final String COLUMN_FIRST_STUDY_COMPLETED = "first_study_completed_at";
-    public static final String COLUMN_FIRST_TODAY_TASKS_COMPLETED = "first_today_tasks_completed_at";
+    public static final String COLUMN_FIRST_STUDY_COMPLETED_AT = "first_study_completed_at";
+    public static final String COLUMN_FIRST_TODAY_TASKS_COMPLETED_AT = "first_today_tasks_completed_at";
     public static final String COLUMN_TODAY_STUDY_COMPLETE_COUNT = "today_study_complete_count";
     public static final String COLUMN_LAST_STUDY_COMPLETED_DATE = "last_study_completed_date";
     public static final String COLUMN_HAS_MASS_BAKING_BREAD_BADGE = "has_mass_baking_bread_badge";

--- a/src/main/java/com/sopt/bbangzip/domain/badge/TodayBreadSoldOutBadge.java
+++ b/src/main/java/com/sopt/bbangzip/domain/badge/TodayBreadSoldOutBadge.java
@@ -16,6 +16,12 @@ public class TodayBreadSoldOutBadge implements Badge{
         return user -> {
             // 아직 뱃지를 획득하지 않았고, 오늘 할 일이 0개일 때만 조건을 만족
             int todayCounts = pieceRetriever.countUnfinishedTodayPieces(user.getId());
+            int completeCounts = pieceRetriever.countFinishedTodayPieces(user.getId());
+
+            // 오늘 할 일이 할당되지 않았을 경우에는 뱃지 획득 못함
+            if (todayCounts + completeCounts == 0) {
+                return false;
+            }
             return user.getAllTasksCompletedAt() == null && todayCounts == 0;
         };
     }

--- a/src/main/java/com/sopt/bbangzip/domain/user/entity/User.java
+++ b/src/main/java/com/sopt/bbangzip/domain/user/entity/User.java
@@ -72,10 +72,10 @@ public class User {
     /**
      * 뱃지 관련 필드들
      */
-    @Column(name = UserTableConstants.COLUMN_FIRST_STUDY_COMPLETED)
+    @Column(name = UserTableConstants.COLUMN_FIRST_STUDY_COMPLETED_AT)
     private LocalDateTime firstStudyCompletedAt = null; // 빵 굽기 시작 획득 여부 (맨 처음으로 '학습 완료')
 
-    @Column(name = UserTableConstants.COLUMN_FIRST_TODAY_TASKS_COMPLETED)
+    @Column(name = UserTableConstants.COLUMN_FIRST_TODAY_TASKS_COMPLETED_AT)
     private LocalDateTime allTasksCompletedAt = null; // 오늘의 빵 완판 획득 여부 (맨 처음으로 '오늘 할 일'을 모두 완료)
 
     @Column(name = UserTableConstants.COLUMN_HAS_MASS_BAKING_BREAD_BADGE)


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #55

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
<img width="935" alt="image" src="https://github.com/user-attachments/assets/9653ba08-7243-460b-8d72-49ef8d61a35e" />
<img width="499" alt="image" src="https://github.com/user-attachments/assets/23695347-261f-4eac-bd77-5d9b9999ff81" />

오늘 할 일이 0개 일 때, 그냥 아무 조각에다가 완료를 찍어도 '오늘의 빵 완판(오늘 할 일 모두 완료 시)' 뱃지가 획득되지 않게 수정했습니다.

## To Reviewers 📢
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
화이팅