### PR TITLE
✨ [feat] #57 마이페이지 상태 확인 API 구현

### DIFF
--- a/src/main/java/com/sopt/bbangzip/domain/user/api/controller/UserController.java
+++ b/src/main/java/com/sopt/bbangzip/domain/user/api/controller/UserController.java
@@ -1,6 +1,11 @@
 package com.sopt.bbangzip.domain.user.api.controller;
 
+import com.sopt.bbangzip.common.annotation.UserId;
+import com.sopt.bbangzip.domain.user.api.dto.UserLevelResponseDto;
+import com.sopt.bbangzip.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -8,4 +13,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class UserController {
+    private final UserService userService;
+
+    @GetMapping("/mypage/level")
+    public ResponseEntity<UserLevelResponseDto> getUserLevelStatus(@UserId final Long userId) {
+        // 마이페이지 조회 시 유저 레벨 업데이트
+        UserLevelResponseDto responseDto = userService.updateAndGetUserLevelStatus(userId);
+
+        return ResponseEntity.ok(responseDto);
+    }
+
 }

--- a/src/main/java/com/sopt/bbangzip/domain/user/api/controller/UserController.java
+++ b/src/main/java/com/sopt/bbangzip/domain/user/api/controller/UserController.java
@@ -16,10 +16,11 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("/mypage/level")
-    public ResponseEntity<UserLevelResponseDto> getUserLevelStatus(@UserId final Long userId) {
+    public ResponseEntity<UserLevelResponseDto> getUserLevelStatus(
+            @UserId final Long userId
+    ) {
         // 마이페이지 조회 시 유저 레벨 업데이트
         UserLevelResponseDto responseDto = userService.updateAndGetUserLevelStatus(userId);
-
         return ResponseEntity.ok(responseDto);
     }
 

--- a/src/main/java/com/sopt/bbangzip/domain/user/api/dto/UserLevelResponseDto.java
+++ b/src/main/java/com/sopt/bbangzip/domain/user/api/dto/UserLevelResponseDto.java
@@ -1,0 +1,7 @@
+package com.sopt.bbangzip.domain.user.api.dto;
+
+public record UserLevelResponseDto(
+        int level,       // 사용자 레벨
+        int badgeCounts, // 뱃지 개수
+        int reward       // 보상 포인트
+) {}

--- a/src/main/java/com/sopt/bbangzip/domain/user/entity/User.java
+++ b/src/main/java/com/sopt/bbangzip/domain/user/entity/User.java
@@ -121,4 +121,23 @@ public class User {
         this.todayStudyCompleteCount++;
         this.lastStudyCompletedDate = now;
     }
+
+    /**
+     * 뱃지 개수를 반환
+     */
+    public int getBadgeCount() {
+        int badgeCount = 0;
+        if (this.firstStudyCompletedAt != null) badgeCount++;
+        if (this.allTasksCompletedAt != null) badgeCount++;
+        if (this.hasMassBakingBreadBadge != null) badgeCount++;
+        return badgeCount;
+    }
+
+    // level 갱신
+    public void updateUserLevel(int newLevel) {
+        if (this.userLevel != newLevel) {
+            this.userLevel = newLevel;
+            this.updatedAt = LocalDateTime.now(); // 레벨 변경 시 updatedAt 갱신
+        }
+    }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/user/service/UserLevelCalculator.java
+++ b/src/main/java/com/sopt/bbangzip/domain/user/service/UserLevelCalculator.java
@@ -1,0 +1,41 @@
+package com.sopt.bbangzip.domain.user.service;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserLevelCalculator {
+
+     // 레벨별 도달 포인트 설정
+    private static final int LEVEL_1_POINT = 200;
+    private static final int LEVEL_2_POINT = 300;
+    private static final int LEVEL_3_POINT = 400;
+
+    // 유저의 포인트를 기준으로 레벨 계산
+    public int calculateLevel(int point) {
+        int totalPoints = 0;
+        int level = 1;
+
+        // 레벨 1 달성 조건
+        totalPoints += LEVEL_1_POINT;
+        if (point <= totalPoints) {
+            return level;
+        }
+
+        // 레벨 2 달성 조건
+        level++;
+        totalPoints += LEVEL_2_POINT;
+        if (point <= totalPoints) {
+            return level;
+        }
+
+        // 레벨 3 달성 조건
+        level++;
+        totalPoints += LEVEL_3_POINT;
+        if (point <= totalPoints) {
+            return level;
+        }
+
+        // 최대 레벨(레벨 3 이상) 설정
+        return level + 1; // 레벨 4 이상일 경우를 위해 추가
+    }
+}

--- a/src/main/java/com/sopt/bbangzip/domain/user/service/UserService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/user/service/UserService.java
@@ -1,11 +1,30 @@
 package com.sopt.bbangzip.domain.user.service;
 
+import com.sopt.bbangzip.domain.user.api.dto.UserLevelResponseDto;
+import com.sopt.bbangzip.domain.user.entity.User;
+import com.sopt.bbangzip.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
+
+    private final UserRetriever userRetriever;
+    private final UserLevelCalculator userLevelCalculator;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public UserLevelResponseDto updateAndGetUserLevelStatus(Long userId) {
+        User user = userRetriever.findByUserId(userId);
+        // 새로운 레벨 계산 및 업데이트
+        int newLevel = userLevelCalculator.calculateLevel(user.getPoint());
+        user.updateUserLevel(newLevel);
+        userRepository.save(user);
+        return new UserLevelResponseDto(user.getUserLevel(), user.getBadgeCount(), user.getPoint());
+    }
+
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #57

## Work Description ✏️

사용자가 현재 마이페이지에서 자신의 레벨 및 보유 포인트, 획득한 뱃지 개수를 확인합니다.

Lv 1 - 0/200
Lv 2 - 200/300
Lv 3 - 300/400

ex. 199점에서 200점이 되는 순간 유저는 Lv 2로 레벨업 합니다.

유저의 레벨을 계산하는 로직은 `UserLevelCalculator` 를 만들어서 구현했습니다.

유저가 `빵굽기 시작 100p`  `빵대량생산 50p` 두 가지 뱃지를 얻은 상태입니다.
![image](https://github.com/user-attachments/assets/8731b308-cbad-467f-84d0-88d55a8b24e0)

유저가 `빵굽기 시작 100p` `빵대량생산 50p` `오늘의 빵 완판 200` 세 가지 뱃지를 얻은 상태입니다.
![image](https://github.com/user-attachments/assets/97659cb3-e36f-40bc-8b99-af7d56e284ad)

![image](https://github.com/user-attachments/assets/f7058cad-5e3c-4d10-9d05-efaf829014e0)

데이터베이스에도 값이 잘 들어오는 것을 확인했습니다.


## To Reviewers 📢

마이페이지에서 유저의 상태를 조회할 때 뿐만 아니라, 뱃지를 받은 직후에 level이 바로 업데이트 되는 로직을 공부조각 완료 체크하기 API   와 공부조각 미완료 체크하기 API 속에도 구현하는 것에 대해서는 어떻게 생각하시나요 ?