### PR TITLE
✨ [feat] #42 오늘 할 일/밀린 공부 view + 정렬 API 구현 완료

### DIFF
--- a/src/main/java/com/sopt/bbangzip/domain/badge/BadgeRetriever.java
+++ b/src/main/java/com/sopt/bbangzip/domain/badge/BadgeRetriever.java
@@ -1,0 +1,23 @@
+package com.sopt.bbangzip.domain.badge;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * 대환핑이 짜줌
+ * 나중에 이거 참고해서 시간 남으면 리팩 할 것.
+ */
+@Component
+public class BadgeRetriever {
+    private final List <Badge> badges;
+
+    public BadgeRetriever(List<Badge> badges) {
+        this.badges = badges;
+    }
+
+    public List<Badge> getBadges() {
+
+        return badges;
+    }
+}

--- a/src/main/java/com/sopt/bbangzip/domain/piece/api/controller/PieceController.java
+++ b/src/main/java/com/sopt/bbangzip/domain/piece/api/controller/PieceController.java
@@ -5,8 +5,9 @@ import com.sopt.bbangzip.common.annotation.UserId;
 import com.sopt.bbangzip.domain.piece.api.dto.request.IsFinishedDto;
 import com.sopt.bbangzip.domain.piece.api.dto.response.MarkDoneResponse;
 
-import com.sopt.bbangzip.domain.piece.api.dto.PieceDeleteRequestDto;
+import com.sopt.bbangzip.domain.piece.api.dto.request.PieceDeleteRequestDto;
 
+import com.sopt.bbangzip.domain.piece.api.dto.response.TodoPiecesResponse;
 import com.sopt.bbangzip.domain.piece.service.PieceService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -54,5 +55,17 @@ public class PieceController {
     ) {
         pieceService.deletePieces(pieceDeleteRequestDto);
         return ResponseEntity.noContent().build();
+    }
+
+    // 오늘 할 일 view + 정렬 API
+    @GetMapping("/pieces/today/orders")
+    public ResponseEntity<TodoPiecesResponse> getTodoPieces(
+            @UserId final long userId,
+            @RequestParam String area, // todo 리스트인지, pending 리스트인지
+            @RequestParam int year,
+            @RequestParam String semester,
+            @RequestParam String sortOption
+    ){
+        return ResponseEntity.ok(pieceService.getPieces(userId, area, year,semester,sortOption));
     }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/piece/api/dto/request/PieceDeleteRequestDto.java
+++ b/src/main/java/com/sopt/bbangzip/domain/piece/api/dto/request/PieceDeleteRequestDto.java
@@ -1,4 +1,4 @@
-package com.sopt.bbangzip.domain.piece.api.dto;
+package com.sopt.bbangzip.domain.piece.api.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;

--- a/src/main/java/com/sopt/bbangzip/domain/piece/api/dto/response/TodoPiecesResponse.java
+++ b/src/main/java/com/sopt/bbangzip/domain/piece/api/dto/response/TodoPiecesResponse.java
@@ -1,0 +1,29 @@
+package com.sopt.bbangzip.domain.piece.api.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Builder
+public record TodoPiecesResponse(
+        Integer toadyCount,
+        Integer completeCount,
+        List<TodoPieceDto> todoPieceStoList,
+        Integer pendingCount
+) {
+    @Builder
+    public record TodoPieceDto(
+            Long pieceId,
+            String subjectName,
+            String examName,
+            String studyCounts,
+            int startPage,
+            int finishPage,
+            String deadline,
+            int remainingDays,
+            boolean isFinished
+    ){
+    }
+}

--- a/src/main/java/com/sopt/bbangzip/domain/piece/repository/PieceRepository.java
+++ b/src/main/java/com/sopt/bbangzip/domain/piece/repository/PieceRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -31,14 +32,13 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
      * 또한, 몇 개나 남았는지 뷰에서 보여줘야 함
      * <p>
      * 오늘 할 일 : is_visible 이 true 여야 됨
-     * 미완료 : is_finished 가 false 면서 오늘 날짜가 piece 의 deadline 과 같거나 이전인 piece 들
+     * 미완료 : is_finished 가 false
      */
     @Query("""
          SELECT COUNT(p)
          FROM Piece p
          WHERE p.isVisible = true
             AND p.isFinished = false
-            AND p.deadline >= CURRENT DATE
             AND p.study.exam.subject.userSubject.user.id = :userId
      """)
     int countUnfinishedTodayPieces(Long userId);
@@ -47,15 +47,151 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
      * 오늘 할 일 중, 완료한 공부 조각 들의 갯수 가져오기
      * 필요한 이유 : 몇 개나 완료했는지 뷰에서 보여줘야 함
      * 오늘 할 일 : is_visible 이 true 여야 됨
-     * 미완료 : is_finished 가 false 면서 오늘 날짜가 piece 의 deadline 과 같거나 이전인 piece 들
+     * 완료 : is_finished 가 true
      */
     @Query("""
             SELECT COUNT(p)
             FROM Piece p
             WHERE p.isVisible = true
-                AND p.isFinished = true 
-                AND p.deadline >= CURRENT DATE 
+                AND p.isFinished = true
                 AND p.study.exam.subject.userSubject.user.id = :userId
             """)
     int countFinishedTodayPieces(Long userId);
+
+    /**
+     * 밀린 공부 조각들의 갯수 가져오기
+     * 밀림 : is_visible 이 false 면서, is_finished 가 false 면서, 오늘 날짜가 piece 의 deadline 보다 이후인 piece 들
+     */
+    @Query("""
+             SELECT COUNT(p)
+             FROM Piece p
+             WHERE p.isVisible = false
+               AND p.isFinished=false
+               AND p.deadline < CURRENT DATE
+               AND p.study.exam.subject.userSubject.user.id = :userId
+            """)
+    int countPendingTodayPieces(Long userId);
+
+    /**
+     * [todo - 최근 등록 순]
+     * 1순위 - 최신 등록순
+     * 2순위 - 과목 내 파트 순서
+     * 오늘 할 일 : is_visible 이 true 여야 됨
+     */
+    @Query("""
+    SELECT p
+    FROM Piece p
+    WHERE p.study.exam.subject.userSubject.user.id = :userId
+        AND p.study.exam.subject.userSubject.year = :year
+        AND p.study.exam.subject.userSubject.semester = :semester
+        AND p.isVisible = true
+    ORDER BY p.createdAt DESC, p.pieceNumber ASC
+    """)
+    List<Piece> findTodoPiecesByRecentOrder(Long userId, int year, String semester);
+
+    /**
+     * [todo - 분량 적은 순]
+     * 1순위 - 분량 적은 양부터 (학습 범위 오름차순)
+     * 2순위 - 마감 기한 빠른 순(오름차 순=오늘 날짜로부터 가까운 순)
+     * 3순위 - 과목 명 가나다 순
+     * 4순위 - 과목 내 파트 순서
+     * 오늘 할 일 : is_visible 이 true 여야 됨
+     */
+    @Query("""
+    SELECT p
+    FROM Piece p
+    WHERE p.study.exam.subject.userSubject.user.id = :userId
+        AND p.isVisible = true
+        AND p.study.exam.subject.userSubject.year = :year
+        AND p.study.exam.subject.userSubject.semester = :semester
+    ORDER BY p.pageAmount ASC, p.deadline ASC,
+             p.study.exam.subject.subjectName ASC,
+             p.pieceNumber ASC
+    """)
+    List<Piece> findTodoPiecesByLeastVolumeOrder(Long userId, int year, String semester);
+
+    /**
+     * [todo - 마감 기한 빠른 순]
+     * 1순위 - 마감 기한 빠른 순(오름차 순=오늘 날짜로부터 가까운 순)
+     * 2순위 - 적은 양부터 (학습 범위 오름차순)
+     * 3순위 - 과목 명 가나다 순
+     * 4순위 - 과목 내 파트 순서
+     * 오늘 할 일 : is_visible 이 true 여야 됨
+     */
+    @Query("""
+    SELECT p
+    FROM Piece p
+    WHERE p.study.exam.subject.userSubject.user.id = :userId
+        AND p.study.exam.subject.userSubject.year = :year
+        AND p.study.exam.subject.userSubject.semester = :semester
+        AND p.isVisible = true
+    ORDER BY p.deadline ASC,
+             p.pageAmount ASC,
+             p.study.exam.subject.subjectName ASC,
+             p.pieceNumber ASC
+    """)
+    List<Piece> findTodoPiecesByNearestDeadlineOrder(Long userId, int year, String semester);
+
+    /**
+     * [pending - 최근 등록 순]
+     * 1순위 - 최신 등록순
+     * 2순위 - 과목 내 파트 순
+     * 밀린 일 : is_visible 이 false 면서, is_finished 가 false 면서, 오늘 날짜가 piece 의 deadline 보다 이후인 piece 들
+     */
+    @Query("""
+    SELECT p
+    FROM Piece p
+    WHERE p.study.exam.subject.userSubject.user.id = :userId
+        AND p.isVisible = false
+        AND p.isFinished = false
+        AND p.deadline < CURRENT_DATE
+        AND p.study.exam.subject.userSubject.year = :year
+        AND p.study.exam.subject.userSubject.semester = :semester
+    ORDER BY p.createdAt DESC, p.pieceNumber ASC
+    """)
+    List<Piece> findPendingPiecesByRecentOrder(Long userId, int year, String semester);
+
+    /**
+     * [pending - 분량 적은 순]
+     * 1순위 - 분량 적은 양부터 (학습 범위 오름차순)
+     * 2순위 - 마감 기한 빠른 순(오름차 순=오늘 날짜로부터 가까운 순)
+     * 3순위 - 과목 명 가나다 순
+     * 4순위 - 과목 내 파트 순서
+     * 밀린 일 : is_visible 이 false 면서, is_finished 가 false 면서, 오늘 날짜가 piece 의 deadline 보다 이후인 piece 들
+     */
+    @Query("""
+    SELECT p
+    FROM Piece p
+    WHERE p.study.exam.subject.userSubject.user.id = :userId
+        AND p.isVisible = false
+        AND p.isFinished = false
+        AND p.deadline < CURRENT_DATE
+        AND p.study.exam.subject.userSubject.year = :year
+        AND p.study.exam.subject.userSubject.semester = :semester
+    ORDER BY p.pageAmount ASC, p.deadline ASC, 
+             p.study.exam.subject.subjectName ASC, p.pieceNumber ASC
+    """)
+    List<Piece> findPendingPiecesByLeastVolumeOrder(Long userId, int year, String semester);
+
+    /**
+     * [pending - 마감 기한 빠른 순]
+     * 1순위 - 마감 기한 빠른 순(오름차 순=오늘 날짜로부터 가까운 순)
+     * 2순위 - 적은 양부터 (학습 범위 오름차순)
+     * 3순위 - 과목 명 가나다 순
+     * 4순위 - 과목 내 파트 순서
+     * 밀린 일 : is_visible 이 false 면서, is_finished 가 false 면서, 오늘 날짜가 piece 의 deadline 보다 이후인 piece 들
+     */
+    @Query("""
+    SELECT p
+    FROM Piece p
+    WHERE p.study.exam.subject.userSubject.user.id = :userId
+        AND p.isVisible = false
+        AND p.isFinished = false
+        AND p.deadline < CURRENT_DATE
+        AND p.study.exam.subject.userSubject.year = :year
+        AND p.study.exam.subject.userSubject.semester = :semester
+    ORDER BY p.deadline ASC, p.pageAmount ASC, 
+             p.study.exam.subject.subjectName ASC, p.pieceNumber ASC
+    """)
+    List<Piece> findPendingPiecesByNearestDeadlineOrder(Long userId, int year,  String semester);
 }

--- a/src/main/java/com/sopt/bbangzip/domain/piece/service/PieceRetriever.java
+++ b/src/main/java/com/sopt/bbangzip/domain/piece/service/PieceRetriever.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+
 import java.util.List;
 
 @Slf4j
@@ -29,7 +30,42 @@ public class PieceRetriever {
     public int countFinishedTodayPieces(final Long userId) {
         return pieceRepository.countFinishedTodayPieces(userId);
     }
-  
+
+    public int countPendingTodayPieces(final Long userId){
+        return pieceRepository.countPendingTodayPieces(userId);
+    }
+
+    /*
+    Todo
+     */
+    public List<Piece> findTodoPiecesByRecentOrder(Long userId, int year, String semester){
+        return  pieceRepository.findTodoPiecesByRecentOrder(userId, year, semester);
+    }
+
+    public List<Piece> findTodoPiecesByLeastVolumeOrder(Long userId, int year, String semester){
+        return pieceRepository.findTodoPiecesByLeastVolumeOrder(userId, year, semester);
+    }
+
+    public List<Piece> findTodoPiecesByNearestDeadlineOrder(Long userId, int year, String semester){
+        return pieceRepository.findTodoPiecesByNearestDeadlineOrder(userId, year, semester);
+    }
+
+    /*
+    Pending
+     */
+    public List<Piece> findPendingPiecesByRecentOrder(Long userId, int year, String semester){
+        return pieceRepository.findPendingPiecesByRecentOrder(userId, year, semester);
+    }
+
+    public List<Piece> findPendingPiecesByLeastVolumeOrder(Long userId, int year, String semester){
+        return pieceRepository.findPendingPiecesByLeastVolumeOrder(userId, year, semester);
+    }
+
+    public List<Piece> findPendingPiecesByNearestDeadlineOrder(Long userId, int year, String semester){
+        return pieceRepository.findPendingPiecesByNearestDeadlineOrder(userId, year, semester);
+    }
+
+
       // 특정 ID 리스트에 해당하는 조각(Piece)들을 조회하는 메서드
     public List<Piece> findAllByIds(List<Long> pieceIds) {
         return pieceRepository.findAllById(pieceIds);

--- a/src/main/java/com/sopt/bbangzip/domain/piece/service/PieceService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/piece/service/PieceService.java
@@ -2,24 +2,25 @@ package com.sopt.bbangzip.domain.piece.service;
 
 
 import com.sopt.bbangzip.domain.badge.BadgeResponse;
-import com.sopt.bbangzip.domain.badge.BadgeService;
 import com.sopt.bbangzip.domain.piece.api.dto.request.IsFinishedDto;
+import com.sopt.bbangzip.domain.piece.api.dto.request.PieceDeleteRequestDto;
 import com.sopt.bbangzip.domain.piece.api.dto.response.MarkDoneResponse;
+import com.sopt.bbangzip.domain.piece.api.dto.response.TodoPiecesResponse;
 import com.sopt.bbangzip.domain.piece.entity.Piece;
 import com.sopt.bbangzip.domain.user.entity.User;
 import com.sopt.bbangzip.domain.user.service.UserRetriever;
 
 import com.sopt.bbangzip.common.exception.base.NotFoundException;
 import com.sopt.bbangzip.common.exception.code.ErrorCode;
-import com.sopt.bbangzip.domain.piece.api.dto.PieceDeleteRequestDto;
 import com.sopt.bbangzip.domain.piece.repository.PieceRepository;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
-
 
 @Service
 @RequiredArgsConstructor
@@ -90,5 +91,71 @@ public class PieceService {
         Piece piece = pieceRetriever.findByPieceIdAndUserId(pieceId, userId);
         User user = userRetriever.findByUserId(userId);
         pieceUpdater.updateStatusUnDone(piece, isFinishedDto, user);
+    }
+
+    public TodoPiecesResponse getPieces(
+            final Long userId,
+            final String area, // "todo" 또는 "pending"
+            final int year,
+            final String semester,
+            final String sortOption
+    ) {
+        User user = userRetriever.findByUserId(userId);
+
+            /**
+             *  area 가 todo 라면 '오늘 할 일' 뷰
+             *  오늘 할 일 : is_visible 이 true 여야 됨
+             */
+        List<Piece> pieces;
+        if (area.equals("todo")) {
+            pieces = switch (sortOption) {
+                case "recent" -> pieceRetriever.findTodoPiecesByRecentOrder(userId, year, semester);
+                case "leastVolume" -> pieceRetriever.findTodoPiecesByLeastVolumeOrder(userId, year, semester);
+                case "nearestDeadline" -> pieceRetriever.findTodoPiecesByNearestDeadlineOrder(userId, year, semester);
+                default -> throw new IllegalArgumentException("Invalid sort option: " + sortOption);
+            };
+        } else {
+            /**
+             * area 가 pending 이라면 '밀린 일' 뷰
+             * 밀린 일 : is_visible 이 false 면서, is_finished 가 false 면서, 오늘 날짜가 piece 의 deadline 보다 이후인 piece 들
+             */
+            pieces = switch (sortOption) {
+                case "recent" -> pieceRetriever.findPendingPiecesByRecentOrder(userId, year, semester);
+                case "leastVolume" -> pieceRetriever.findPendingPiecesByLeastVolumeOrder(userId, year, semester);
+                case "nearestDeadline" -> pieceRetriever.findPendingPiecesByNearestDeadlineOrder(userId, year, semester);
+                default -> throw new IllegalArgumentException("Invalid sort option: " + sortOption);
+            };
+        }
+
+        int todayCount = pieceRetriever.countUnfinishedTodayPieces(userId);
+        int completedCount = pieceRetriever.countFinishedTodayPieces(userId);
+        int pendingCount = pieceRetriever.countPendingTodayPieces(userId);
+
+        // 5. Piece 데이터를 TodoPieceDto로 변환
+        List<TodoPiecesResponse.TodoPieceDto> todoPieceDtos = pieces.stream()
+                .map(piece -> TodoPiecesResponse.TodoPieceDto.builder()
+                        .pieceId(piece.getId())
+                        .subjectName(piece.getStudy().getExam().getSubject().getSubjectName())
+                        .examName(piece.getStudy().getExam().getExamName())
+                        .studyCounts(piece.getStudy().getStudyContents())
+                        .startPage(piece.getStartPage())
+                        .finishPage(piece.getFinishPage())
+                        .deadline(piece.getDeadline().toString())
+                        .remainingDays(calculateRemainingDays(piece.getDeadline()))
+                        .isFinished(piece.getIsFinished())
+                        .build())
+                .toList();
+
+        return TodoPiecesResponse.builder()
+                .toadyCount(area.equals("todo") ? todayCount : null) // "pending"일 경우 null
+                .completeCount(area.equals("todo") ? completedCount : null) // "pending"일 경우 null
+                .pendingCount(pendingCount)
+                .todoPieceStoList(todoPieceDtos)
+                .build();
+    }
+
+    private int calculateRemainingDays(LocalDate deadline) {
+        int remainingDays = (int) ChronoUnit.DAYS.between(LocalDate.now(), deadline);
+        return remainingDays >= 0 ? -remainingDays : Math.abs(remainingDays); // 밀린 일 양수, 남은 일 음수
     }
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #42 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
오늘 할 일/밀린 공부 view + 정렬 API 구현 완료했습니다.
- remainingDays 는 밀린 일은 +, 아닌 일은 - 로 응답 내려갑니다.
- 정렬 기준은 아래와 같습니다
<img width="415" alt="image" src="https://github.com/user-attachments/assets/0b93d6a2-4b90-4eff-9705-509154d22b42" />


## To Reviewers 📢
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
테스트 다 완료했습니다.. (저희 함께 옆에서 확인했죵?)
케이스 너무 많습니다.. 
우리 둘 다 고생했습니다 예은 사장님.. ㅠㅠ
