### PR TITLE
✨ [feat] #61 뱃지 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/sopt/bbangzip/common/exception/code/ErrorCode.java
+++ b/src/main/java/com/sopt/bbangzip/common/exception/code/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode implements BbangzipErrorCode{
     NOT_FOUND_PIECE(HttpStatus.NOT_FOUND, "error", "존재하지 않는 Piece 입니다"),
     NOT_FOUND_STUDY(HttpStatus.NOT_FOUND, "error", "존재하지 않는 공부범위(교재)입니다"),
     NOT_FOUND_EXAM(HttpStatus.NOT_FOUND, "error", "존재하지 않는 시험입니다."),
+    NOT_FOUND_BADGE(HttpStatus.NOT_FOUND, "error", "존재하지 않는 뱃지입니다."),
 
     // 500
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "error", "서버 내부 오류입니다."),

--- a/src/main/java/com/sopt/bbangzip/domain/badge/Badge.java
+++ b/src/main/java/com/sopt/bbangzip/domain/badge/Badge.java
@@ -12,4 +12,5 @@ public interface Badge {
     String getImage(); // 뱃지 이미지 반환
     String getCategory(); // 뱃지 카테고리 반환
     Boolean isLocked(User user); // 잠금 여부 반환
+    String getAchievementCondition();
 }

--- a/src/main/java/com/sopt/bbangzip/domain/badge/BadgeRetriever.java
+++ b/src/main/java/com/sopt/bbangzip/domain/badge/BadgeRetriever.java
@@ -17,7 +17,6 @@ public class BadgeRetriever {
     }
 
     public List<Badge> getBadges() {
-
         return badges;
     }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/badge/MassBakingBreadBadge.java
+++ b/src/main/java/com/sopt/bbangzip/domain/badge/MassBakingBreadBadge.java
@@ -43,4 +43,9 @@ public class MassBakingBreadBadge implements Badge{
         // 유저가 조건을 만족하면 잠금 해제
         return !getCondition().isEligible(user);
     }
+
+    @Override
+    public String getAchievementCondition(){
+        return "24시간 내 '학습 완료'를 3회 완료한 경우";
+    }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/badge/StartBakingBreadBadge.java
+++ b/src/main/java/com/sopt/bbangzip/domain/badge/StartBakingBreadBadge.java
@@ -43,4 +43,9 @@ public class StartBakingBreadBadge implements Badge{
         // 유저가 조건을 만족하면 잠금 해제
         return !getCondition().isEligible(user);
     }
+
+    @Override
+    public String getAchievementCondition(){
+        return "최초로 '학습완료'를 수행한 경우";
+    }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/badge/TodayBreadSoldOutBadge.java
+++ b/src/main/java/com/sopt/bbangzip/domain/badge/TodayBreadSoldOutBadge.java
@@ -54,7 +54,11 @@ public class TodayBreadSoldOutBadge implements Badge{
 
     @Override
     public Boolean isLocked(User user) {
-        // 유저가 조건을 만족하면 잠금 해제
         return !getCondition().isEligible(user);
+    }
+
+    @Override
+    public String getAchievementCondition(){
+        return "최초로 '오늘 할 일'을 모두 완료한 경우";
     }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/badge/api/controller/BadgeController.java
+++ b/src/main/java/com/sopt/bbangzip/domain/badge/api/controller/BadgeController.java
@@ -22,16 +22,13 @@ public class BadgeController {
 
     @GetMapping
     public ResponseEntity<BadgeListResponse> getBadgeList(@UserId final Long userId) {
-        BadgeListResponse badgeList = badgeService.getBadgeList(userId);
-        return ResponseEntity.ok(badgeList);
+        return ResponseEntity.ok( badgeService.getBadgeList(userId));
     }
 
     @GetMapping("/{badgeName}")
     public ResponseEntity<BadgeDetailResponse> getBadgeDetails(
             @PathVariable String badgeName,
             @UserId final Long userId) {
-
-        BadgeDetailResponse badgeDetail = badgeService.getBadgeDetail(userId, badgeName);
-        return ResponseEntity.ok(badgeDetail);
+        return ResponseEntity.ok(badgeService.getBadgeDetail(userId, badgeName));
     }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/badge/api/controller/BadgeController.java
+++ b/src/main/java/com/sopt/bbangzip/domain/badge/api/controller/BadgeController.java
@@ -1,11 +1,14 @@
 package com.sopt.bbangzip.domain.badge.api.controller;
 
 import com.sopt.bbangzip.common.annotation.UserId;
+import com.sopt.bbangzip.common.dto.ResponseDto;
+import com.sopt.bbangzip.domain.badge.api.dto.response.BadgeDetailResponse;
 import com.sopt.bbangzip.domain.badge.api.dto.response.BadgeListResponse;
 import com.sopt.bbangzip.domain.badge.service.BadgeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,4 +26,12 @@ public class BadgeController {
         return ResponseEntity.ok(badgeList);
     }
 
+    @GetMapping("/{badgeName}")
+    public ResponseEntity<BadgeDetailResponse> getBadgeDetails(
+            @PathVariable String badgeName,
+            @UserId final Long userId) {
+
+        BadgeDetailResponse badgeDetail = badgeService.getBadgeDetail(userId, badgeName);
+        return ResponseEntity.ok(badgeDetail);
+    }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/badge/api/dto/response/BadgeDetailResponse.java
+++ b/src/main/java/com/sopt/bbangzip/domain/badge/api/dto/response/BadgeDetailResponse.java
@@ -1,0 +1,13 @@
+package com.sopt.bbangzip.domain.badge.api.dto.response;
+
+import java.util.List;
+
+public record BadgeDetailResponse(
+        String badgeName,
+        String badgeImage,
+        List<String> hashTags,
+        String achievementCondition,
+        int reward,
+        boolean badgeIsLocked
+) {
+}

--- a/src/main/java/com/sopt/bbangzip/domain/badge/service/BadgeService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/badge/service/BadgeService.java
@@ -1,7 +1,10 @@
 package com.sopt.bbangzip.domain.badge.service;
 
+import com.sopt.bbangzip.common.exception.base.NotFoundException;
+import com.sopt.bbangzip.common.exception.code.ErrorCode;
 import com.sopt.bbangzip.domain.badge.Badge;
 import com.sopt.bbangzip.domain.badge.BadgeCondition;
+import com.sopt.bbangzip.domain.badge.api.dto.response.BadgeDetailResponse;
 import com.sopt.bbangzip.domain.badge.api.dto.response.BadgeListResponse;
 import com.sopt.bbangzip.domain.badge.api.dto.response.BadgeResponse;
 import com.sopt.bbangzip.domain.piece.service.PieceRetriever;
@@ -108,5 +111,26 @@ public class BadgeService {
             default:
                 return true;
         }
+    }
+
+    /**
+     * 특정 뱃지의 상세 정보 조회
+     */
+    public BadgeDetailResponse getBadgeDetail(Long userId, String badgeName) {
+        User user = userRetriever.findByUserId(userId);
+
+        // 특정 이름의 뱃지 검색
+        return badges.stream()
+                .filter(badge -> badge.getName().equals(badgeName))
+                .findFirst()
+                .map(badge -> new BadgeDetailResponse(
+                        badge.getName(),
+                        badge.getImage(),
+                        badge.getHashTags(),
+                        badge.getAchievementCondition(),
+                        badge.getReward(),
+                        badge.isLocked(user)
+                ))
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_BADGE));
     }
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #61 

## Work Description ✏️
뱃지 상세조회 기능을 구현했습니다.
![image](https://github.com/user-attachments/assets/287c7da1-5bde-4021-bcd6-4ca41096b46d)


## Trouble Shooting ⚽️
일반적인 경우에는 id로 뱃지를 조회하는 것이 일반적이지만, 인터페이스로 구현했기 때문에 뱃지의 이름을 보내는 것으로 구현했습니다.


## To Reviewers 📢
고쳐야할 게 있다면 알려주세요
