### PR TITLE
✏️ [fix] #68 공부 조각 삭제하기 API 수정

### DIFF
--- a/src/main/java/com/sopt/bbangzip/domain/piece/api/dto/request/PieceDeleteRequestDto.java
+++ b/src/main/java/com/sopt/bbangzip/domain/piece/api/dto/request/PieceDeleteRequestDto.java
@@ -1,15 +1,10 @@
 package com.sopt.bbangzip.domain.piece.api.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
 public record PieceDeleteRequestDto(
-        @NotNull Long subjectId,
-        @NotBlank String subjectName,
-        @NotBlank String examName,
         @NotEmpty List<Long> pieceIds
 ) {
 }

--- a/src/main/java/com/sopt/bbangzip/domain/piece/service/PieceRemover.java
+++ b/src/main/java/com/sopt/bbangzip/domain/piece/service/PieceRemover.java
@@ -1,0 +1,19 @@
+package com.sopt.bbangzip.domain.piece.service;
+
+import com.sopt.bbangzip.domain.piece.entity.Piece;
+import com.sopt.bbangzip.domain.piece.repository.PieceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PieceRemover {
+
+    private final PieceRepository pieceRepository;
+
+    public void removePieces(List<Piece> pieces) {
+        pieceRepository.deleteAll(pieces);
+    }
+}

--- a/src/main/java/com/sopt/bbangzip/domain/piece/service/PieceService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/piece/service/PieceService.java
@@ -31,8 +31,8 @@ public class PieceService {
     private final PieceUpdater pieceUpdater;
     private final PieceSaver pieceSaver;
   
-    private final PieceRepository pieceRepository;
-  
+    private final PieceRemover pieceRemover;
+
     @Transactional
     public void deletePieces(PieceDeleteRequestDto pieceDeleteRequestDto) {
         List<Long> pieceIds = pieceDeleteRequestDto.pieceIds();
@@ -42,7 +42,8 @@ public class PieceService {
         if (pieces.isEmpty() || pieces.size() != pieceIds.size()) {
             throw new NotFoundException(ErrorCode.NOT_FOUND_PIECE);
         }
-        pieceRepository.deleteAll(pieces);
+
+        pieceRemover.removePieces(pieces);
     }
 
     @Transactional


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #68

## Work Description ✏️
공부 조각 삭제하기 API 를 수정했습니다. 

`PieceDeleteRequestDto` 수정하여 필요없는 정보를 삭제했습니다.
`PieceRemover` 추가하여 `Service`의 책임을 분리했습니다.

![image](https://github.com/user-attachments/assets/8b90458e-a70b-434e-b51e-04bf54a3ccc2)



## To Reviewers 📢
맛있는 빵 열심히 만들어보아요 ~ 새벽근무도 화이팅 !
