### PR TITLE
✏️ [fix] #71 공부 범위(교재) 추가하기 API  수정

### DIFF
--- a/src/main/java/com/sopt/bbangzip/domain/study/api/controller/StudyController.java
+++ b/src/main/java/com/sopt/bbangzip/domain/study/api/controller/StudyController.java
@@ -17,11 +17,12 @@ public class StudyController {
     private final StudyService studyService;
 
     @PostMapping("/studies")
-    public ResponseEntity<StudyCreateResponseDto> createStudy(
+    public ResponseEntity<Void> createStudy(
             @UserId final Long userId,
             @RequestBody @Valid final StudyCreateRequestDto studyCreateRequestDto
     ) {
-        StudyCreateResponseDto responseDto = studyService.createStudy(userId, studyCreateRequestDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+        studyService.createStudy(userId, studyCreateRequestDto);
+        return ResponseEntity.noContent().build();
     }
+
 }

--- a/src/main/java/com/sopt/bbangzip/domain/study/api/controller/StudyController.java
+++ b/src/main/java/com/sopt/bbangzip/domain/study/api/controller/StudyController.java
@@ -18,7 +18,7 @@ public class StudyController {
 
     @PostMapping("/studies")
     public ResponseEntity<Void> createStudy(
-            @UserId final Long userId,
+            @UserId final long userId,
             @RequestBody @Valid final StudyCreateRequestDto studyCreateRequestDto
     ) {
         studyService.createStudy(userId, studyCreateRequestDto);

--- a/src/main/java/com/sopt/bbangzip/domain/study/api/dto/request/StudyCreateRequestDto.java
+++ b/src/main/java/com/sopt/bbangzip/domain/study/api/dto/request/StudyCreateRequestDto.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 public record StudyCreateRequestDto(
         @NotNull Long subjectId,
-        @NotBlank String subjectName,
         @NotBlank String examName,
         @NotNull String examDate,
         @NotBlank String studyContents,

--- a/src/main/java/com/sopt/bbangzip/domain/study/service/StudyService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/study/service/StudyService.java
@@ -29,24 +29,24 @@ public class StudyService {
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy년MM월dd일");
 
     @Transactional
-    public StudyCreateResponseDto createStudy(Long userId, StudyCreateRequestDto requestDto) {
+    public StudyCreateResponseDto createStudy(Long userId, StudyCreateRequestDto studyCreateRequestDto) {
 
-        Subject subject = subjectRetriever.findByUserIdAndSubjectName(userId, requestDto.subjectId(), requestDto.subjectName());
+        Subject subject = subjectRetriever.findById(studyCreateRequestDto.subjectId());
 
         Exam exam = Exam.builder()
-                .examName(requestDto.examName())
-                .examDate(parseStringToLocalDate(requestDto.examDate()))
+                .examName(studyCreateRequestDto.examName())
+                .examDate(parseStringToLocalDate(studyCreateRequestDto.examDate()))
                 .subject(subject)
                 .build();
         examSaver.save(exam);
 
         Study study = Study.builder()
                 .exam(exam)
-                .studyContents(requestDto.studyContents())
+                .studyContents(studyCreateRequestDto.studyContents())
                 .build();
         studySaver.save(study);
 
-        List<Piece> pieces = requestDto.pieceList().stream()
+        List<Piece> pieces = studyCreateRequestDto.pieceList().stream()
                 .map(pieceDto -> Piece.builder()
                         .study(study)
                         .startPage(pieceDto.startPage())

--- a/src/main/java/com/sopt/bbangzip/domain/subject/repository/SubjectRepository.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/repository/SubjectRepository.java
@@ -17,10 +17,7 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
     // 특정 UserSubject ID와 과목 ID로 과목 조회
     List<Subject> findByIdInAndUserSubjectId(List<Long> subjectIds, Long userSubjectId);
 
-    Optional<Subject> findById(Long subjectId);
-
-    // UserSubject와 SubjectName으로 Subject 조회
-    Optional<Subject> findByUserSubjectAndSubjectName(UserSubject userSubject, String subjectName);
+    Optional<Subject> findById(Long id);
 
     Optional<Subject> findByUserSubject_UserIdAndIdAndSubjectName(Long userId, Long subjectId, String subjectName);
 }

--- a/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectRetriever.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectRetriever.java
@@ -39,8 +39,8 @@ public class SubjectRetriever {
     }
 
     // 과목 조회 (subjectId로 단건조회)
-    public Subject findById(Long Id) {
-        return subjectRepository.findById(Id)
+    public Subject findById(Long id) {
+        return subjectRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_SUBJECT));
     }
 

--- a/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectRetriever.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectRetriever.java
@@ -39,18 +39,8 @@ public class SubjectRetriever {
     }
 
     // 과목 조회 (subjectId로 단건조회)
-    public Subject findById(Long subjectId) {
-        return subjectRepository.findById(subjectId)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_SUBJECT));
-    }
-
-    // UserId와 SubjectName으로 특정 과목(Subject) 조회
-    public Subject findByUserIdAndSubjectName(Long userId, int year, String semester, String subjectName) {
-        // UserSubject 조회
-        UserSubject userSubject = findByUserIdAndYearAndSemester(userId, year, semester);
-
-        // Subject 조회
-        return subjectRepository.findByUserSubjectAndSubjectName(userSubject, subjectName)
+    public Subject findById(Long Id) {
+        return subjectRepository.findById(Id)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_SUBJECT));
     }
 


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #71 

## Work Description ✏️
요청을 보낼 때 `subjectId` 를 보내므로 과목명을 알지 않아도 되므로 해당 내용 수정했습니다.

응답도 `POST` 매핑이므로 `204 No Content` 를 반환하는 것으로 수정했습니다.

![image](https://github.com/user-attachments/assets/6ca5b756-e814-42f5-8a79-f9a0f6c7ed5e)


## To Reviewers 📢
`StudyCreateResponseDto` 는 바로 중간고사/ 기말고사 필터링 할 때 활용하기 위해서 지우지 않았습니다 !! 나중에 지울게용
