### PR TITLE
:sparkles: [feat] #91 소셜 로그인 API 에서 code 대신 accessToken 사용해서 구현하도록 수정

### DIFF
--- a/src/main/java/com/sopt/bbangzip/domain/auth/AuthService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/auth/AuthService.java
@@ -58,10 +58,8 @@ public class AuthService {
         System.out.println("Kakao Client ID: " + kakaoClientId);
         System.out.println("Kakao Redirect URI: " + kakaoRedirectUri);
 
-        // 1. kakao 토큰 요청
-        KakaoTokenResponse kakaoTokenResponse = kakaoService.getToken(code, kakaoClientId, kakaoRedirectUri);
-        // 2. kakao 사용자 정보 요청
-        KakaoUserInfoResponse kakaoUserInfoResponse = kakaoService.getUserInfo(kakaoTokenResponse.accessToken());
+        // accessToken(==code) 받아서 kakao 사용자 정보 요청
+        KakaoUserInfoResponse kakaoUserInfoResponse = kakaoService.getUserInfo(code);
 
         User user = userRetriever.findByPlatformUserId(
                 kakaoUserInfoResponse.id()


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #91 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
https://devtalk.kakao.com/t/ios/130676/5
웹에서는 클라이언트가 리다이렉트되면서 받은 인가코드로 서버에 요청해서 서버가 카카오와 통신해서 인증을 수행했는데,
앱에서는 클라이언트가 카카오로부터 엑세스 토큰까지 받아온다는 사실을 알게 되어서 해당 방향으로 로직 수정했습니다.

