### PR TITLE
✨ [feat] #40 학기별 과목 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/sopt/bbangzip/domain/piece/repository/PieceRepository.java
+++ b/src/main/java/com/sopt/bbangzip/domain/piece/repository/PieceRepository.java
@@ -14,28 +14,28 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
 
     // 유저가 선택한 공부 조각 가져오는
     @Query("""
-        SELECT p
-        FROM Piece p
-        JOIN p.study s
-        JOIN s.exam e
-        JOIN e.subject sub
-        JOIN sub.userSubject us
-        JOIN us.user u
-        WHERE p.id = :pieceId AND u.id = :userId
-    """)
+                SELECT p
+                FROM Piece p
+                JOIN p.study s
+                JOIN s.exam e
+                JOIN e.subject sub
+                JOIN sub.userSubject us
+                JOIN us.user u
+                WHERE p.id = :pieceId AND u.id = :userId
+            """)
     Optional<Piece> findByPieceIdAndUserId(@Param("pieceId") Long pieceId, @Param("userId") Long userId);
 
     // 유저가 선택한 공부 조각'들' 가겨오는
     @Query("""
-        SELECT p
-        FROM Piece p
-        JOIN p.study s
-        JOIN s.exam e
-        JOIN e.subject sub
-        JOIN sub.userSubject us
-        JOIN us.user u
-        WHERE p.id IN :pieceIds AND u.id = :userId
-""")
+                    SELECT p
+                    FROM Piece p
+                    JOIN p.study s
+                    JOIN s.exam e
+                    JOIN e.subject sub
+                    JOIN sub.userSubject us
+                    JOIN us.user u
+                    WHERE p.id IN :pieceIds AND u.id = :userId
+            """)
     List<Piece> findByPiecesIdAndUserId(@Param("pieceIds") List<Long> pieceIds, @Param("userId") Long userId);
 
 
@@ -48,12 +48,12 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
      * 미완료 : is_finished 가 false
      */
     @Query("""
-         SELECT COUNT(p)
-         FROM Piece p
-         WHERE p.isVisible = true
-            AND p.isFinished = false
-            AND p.study.exam.subject.userSubject.user.id = :userId
-     """)
+                SELECT COUNT(p)
+                FROM Piece p
+                WHERE p.isVisible = true
+                   AND p.isFinished = false
+                   AND p.study.exam.subject.userSubject.user.id = :userId
+            """)
     int countUnfinishedTodayPieces(Long userId);
 
     /**
@@ -92,14 +92,14 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
      * 오늘 할 일 : is_visible 이 true 여야 됨
      */
     @Query("""
-    SELECT p
-    FROM Piece p
-    WHERE p.study.exam.subject.userSubject.user.id = :userId
-        AND p.study.exam.subject.userSubject.year = :year
-        AND p.study.exam.subject.userSubject.semester = :semester
-        AND p.isVisible = true
-    ORDER BY p.createdAt DESC, p.pieceNumber ASC
-    """)
+            SELECT p
+            FROM Piece p
+            WHERE p.study.exam.subject.userSubject.user.id = :userId
+                AND p.study.exam.subject.userSubject.year = :year
+                AND p.study.exam.subject.userSubject.semester = :semester
+                AND p.isVisible = true
+            ORDER BY p.createdAt DESC, p.pieceNumber ASC
+            """)
     List<Piece> findTodoPiecesByRecentOrder(Long userId, int year, String semester);
 
     /**
@@ -111,16 +111,16 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
      * 오늘 할 일 : is_visible 이 true 여야 됨
      */
     @Query("""
-    SELECT p
-    FROM Piece p
-    WHERE p.study.exam.subject.userSubject.user.id = :userId
-        AND p.isVisible = true
-        AND p.study.exam.subject.userSubject.year = :year
-        AND p.study.exam.subject.userSubject.semester = :semester
-    ORDER BY p.pageAmount ASC, p.deadline ASC,
-             p.study.exam.subject.subjectName ASC,
-             p.pieceNumber ASC
-    """)
+            SELECT p
+            FROM Piece p
+            WHERE p.study.exam.subject.userSubject.user.id = :userId
+                AND p.isVisible = true
+                AND p.study.exam.subject.userSubject.year = :year
+                AND p.study.exam.subject.userSubject.semester = :semester
+            ORDER BY p.pageAmount ASC, p.deadline ASC,
+                     p.study.exam.subject.subjectName ASC,
+                     p.pieceNumber ASC
+            """)
     List<Piece> findTodoPiecesByLeastVolumeOrder(Long userId, int year, String semester);
 
     /**
@@ -132,17 +132,17 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
      * 오늘 할 일 : is_visible 이 true 여야 됨
      */
     @Query("""
-    SELECT p
-    FROM Piece p
-    WHERE p.study.exam.subject.userSubject.user.id = :userId
-        AND p.study.exam.subject.userSubject.year = :year
-        AND p.study.exam.subject.userSubject.semester = :semester
-        AND p.isVisible = true
-    ORDER BY p.deadline ASC,
-             p.pageAmount ASC,
-             p.study.exam.subject.subjectName ASC,
-             p.pieceNumber ASC
-    """)
+            SELECT p
+            FROM Piece p
+            WHERE p.study.exam.subject.userSubject.user.id = :userId
+                AND p.study.exam.subject.userSubject.year = :year
+                AND p.study.exam.subject.userSubject.semester = :semester
+                AND p.isVisible = true
+            ORDER BY p.deadline ASC,
+                     p.pageAmount ASC,
+                     p.study.exam.subject.subjectName ASC,
+                     p.pieceNumber ASC
+            """)
     List<Piece> findTodoPiecesByNearestDeadlineOrder(Long userId, int year, String semester);
 
     /**
@@ -152,16 +152,16 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
      * 밀린 일 : is_visible 이 false 면서, is_finished 가 false 면서, 오늘 날짜가 piece 의 deadline 보다 이후인 piece 들
      */
     @Query("""
-    SELECT p
-    FROM Piece p
-    WHERE p.study.exam.subject.userSubject.user.id = :userId
-        AND p.isVisible = false
-        AND p.isFinished = false
-        AND p.deadline < CURRENT_DATE
-        AND p.study.exam.subject.userSubject.year = :year
-        AND p.study.exam.subject.userSubject.semester = :semester
-    ORDER BY p.createdAt DESC, p.pieceNumber ASC
-    """)
+            SELECT p
+            FROM Piece p
+            WHERE p.study.exam.subject.userSubject.user.id = :userId
+                AND p.isVisible = false
+                AND p.isFinished = false
+                AND p.deadline < CURRENT_DATE
+                AND p.study.exam.subject.userSubject.year = :year
+                AND p.study.exam.subject.userSubject.semester = :semester
+            ORDER BY p.createdAt DESC, p.pieceNumber ASC
+            """)
     List<Piece> findPendingPiecesByRecentOrder(Long userId, int year, String semester);
 
     /**
@@ -173,17 +173,17 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
      * 밀린 일 : is_visible 이 false 면서, is_finished 가 false 면서, 오늘 날짜가 piece 의 deadline 보다 이후인 piece 들
      */
     @Query("""
-    SELECT p
-    FROM Piece p
-    WHERE p.study.exam.subject.userSubject.user.id = :userId
-        AND p.isVisible = false
-        AND p.isFinished = false
-        AND p.deadline < CURRENT_DATE
-        AND p.study.exam.subject.userSubject.year = :year
-        AND p.study.exam.subject.userSubject.semester = :semester
-    ORDER BY p.pageAmount ASC, p.deadline ASC,
-             p.study.exam.subject.subjectName ASC, p.pieceNumber ASC
-    """)
+            SELECT p
+            FROM Piece p
+            WHERE p.study.exam.subject.userSubject.user.id = :userId
+                AND p.isVisible = false
+                AND p.isFinished = false
+                AND p.deadline < CURRENT_DATE
+                AND p.study.exam.subject.userSubject.year = :year
+                AND p.study.exam.subject.userSubject.semester = :semester
+            ORDER BY p.pageAmount ASC, p.deadline ASC,
+                     p.study.exam.subject.subjectName ASC, p.pieceNumber ASC
+            """)
     List<Piece> findPendingPiecesByLeastVolumeOrder(Long userId, int year, String semester);
 
     /**
@@ -195,31 +195,31 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
      * 밀린 일 : is_visible 이 false 면서, is_finished 가 false 면서, 오늘 날짜가 piece 의 deadline 보다 이후인 piece 들
      */
     @Query("""
-    SELECT p
-    FROM Piece p
-    WHERE p.study.exam.subject.userSubject.user.id = :userId
-        AND p.isVisible = false
-        AND p.isFinished = false
-        AND p.deadline < CURRENT_DATE
-        AND p.study.exam.subject.userSubject.year = :year
-        AND p.study.exam.subject.userSubject.semester = :semester
-    ORDER BY p.deadline ASC, p.pageAmount ASC, 
-             p.study.exam.subject.subjectName ASC, p.pieceNumber ASC
-    """)
-    List<Piece> findPendingPiecesByNearestDeadlineOrder(Long userId, int year,  String semester);
+            SELECT p
+            FROM Piece p
+            WHERE p.study.exam.subject.userSubject.user.id = :userId
+                AND p.isVisible = false
+                AND p.isFinished = false
+                AND p.deadline < CURRENT_DATE
+                AND p.study.exam.subject.userSubject.year = :year
+                AND p.study.exam.subject.userSubject.semester = :semester
+            ORDER BY p.deadline ASC, p.pageAmount ASC, 
+                     p.study.exam.subject.subjectName ASC, p.pieceNumber ASC
+            """)
+    List<Piece> findPendingPiecesByNearestDeadlineOrder(Long userId, int year, String semester);
 
     /**
      * [오늘 할 공부에 추가할 수 있는 조각들 갯수]
      * is_visible = false && is_finished = false && deadline >= current date
      */
     @Query("""
-             SELECT COUNT(p)
-             FROM Piece p
-             WHERE p.isVisible = false
-               AND p.isFinished = false
-               AND p.deadline >= CURRENT DATE
-               AND p.study.exam.subject.userSubject.user.id = :userId
-    """)
+                     SELECT COUNT(p)
+                     FROM Piece p
+                     WHERE p.isVisible = false
+                       AND p.isFinished = false
+                       AND p.deadline >= CURRENT DATE
+                       AND p.study.exam.subject.userSubject.user.id = :userId
+            """)
     int findAddTodoPieceCount(Long userId, int year, String semester);
 
     /**
@@ -229,17 +229,17 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
      * is_visible = false && is_finished = false && deadline >= current date
      */
     @Query("""
-    SELECT p
-    FROM Piece p
-    WHERE p.study.exam.subject.userSubject.user.id = :userId
-        AND p.study.exam.subject.userSubject.year = :year
-        AND p.study.exam.subject.userSubject.semester = :semester
-        AND p.isVisible = false
-        AND p.isFinished = false
-        AND p.deadline >= CURRENT_DATE
-    ORDER BY p.createdAt DESC, p.pieceNumber ASC
-    """)
-    List<Piece> findAddTodoPieceListByRecentOrder(Long userId, int year,  String semester);
+            SELECT p
+            FROM Piece p
+            WHERE p.study.exam.subject.userSubject.user.id = :userId
+                AND p.study.exam.subject.userSubject.year = :year
+                AND p.study.exam.subject.userSubject.semester = :semester
+                AND p.isVisible = false
+                AND p.isFinished = false
+                AND p.deadline >= CURRENT_DATE
+            ORDER BY p.createdAt DESC, p.pieceNumber ASC
+            """)
+    List<Piece> findAddTodoPieceListByRecentOrder(Long userId, int year, String semester);
 
     /**
      * [오늘 할 공부에 추가할 수 있는 조각들 찾기 - 분량 적은 순 ]
@@ -250,20 +250,20 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
      * is_visible = false && is_finished = false && deadline >= current date
      */
     @Query("""
-    SELECT p
-    FROM Piece p
-    WHERE p.study.exam.subject.userSubject.user.id = :userId
-        AND p.study.exam.subject.userSubject.year = :year
-        AND p.study.exam.subject.userSubject.semester = :semester
-        AND p.isVisible = false
-        AND p.isFinished = false
-        AND p.deadline >= CURRENT_DATE
-    ORDER BY p.pageAmount ASC,
-             p.deadline ASC,
-             p.study.exam.subject.subjectName ASC,
-             p.pieceNumber ASC
-    """)
-    List<Piece> findAddTodoPieceListByLeastVolumeOrder(Long userId, int year,  String semester);
+            SELECT p
+            FROM Piece p
+            WHERE p.study.exam.subject.userSubject.user.id = :userId
+                AND p.study.exam.subject.userSubject.year = :year
+                AND p.study.exam.subject.userSubject.semester = :semester
+                AND p.isVisible = false
+                AND p.isFinished = false
+                AND p.deadline >= CURRENT_DATE
+            ORDER BY p.pageAmount ASC,
+                     p.deadline ASC,
+                     p.study.exam.subject.subjectName ASC,
+                     p.pieceNumber ASC
+            """)
+    List<Piece> findAddTodoPieceListByLeastVolumeOrder(Long userId, int year, String semester);
 
     /**
      * [오늘 할 공부에 추가할 수 있는 조각들 찾기 - 마감 기한 빠른 순 ]
@@ -274,33 +274,107 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
      * is_visible = false && is_finished = false && deadline >= current date
      */
     @Query("""
-    SELECT p
-    FROM Piece p
-    WHERE p.study.exam.subject.userSubject.user.id = :userId
-        AND p.study.exam.subject.userSubject.year = :year
-        AND p.study.exam.subject.userSubject.semester = :semester
-        AND p.isVisible = false
-        AND p.isFinished = false
-        AND p.deadline >= CURRENT_DATE
-    ORDER BY p.deadline ASC,
-             p.pageAmount ASC,
-             p.study.exam.subject.subjectName ASC,
-             p.pieceNumber ASC
-    """)
-    List<Piece> findAddTodoPieceListByNearestDeadlineOrder(Long userId, int year,  String semester);
-
-    @Query("""
             SELECT p
             FROM Piece p
-            JOIN p.study s
-            JOIN s.exam e
-            JOIN e.subject sub
-            JOIN sub.userSubject us
-            JOIN us.user u
-            WHERE e.id = :examId
-              AND u.id = :userId
-           """)
+            WHERE p.study.exam.subject.userSubject.user.id = :userId
+                AND p.study.exam.subject.userSubject.year = :year
+                AND p.study.exam.subject.userSubject.semester = :semester
+                AND p.isVisible = false
+                AND p.isFinished = false
+                AND p.deadline >= CURRENT_DATE
+            ORDER BY p.deadline ASC,
+                     p.pageAmount ASC,
+                     p.study.exam.subject.subjectName ASC,
+                     p.pieceNumber ASC
+            """)
+    List<Piece> findAddTodoPieceListByNearestDeadlineOrder(Long userId, int year, String semester);
+
+    @Query("""
+             SELECT p
+             FROM Piece p
+             JOIN p.study s
+             JOIN s.exam e
+             JOIN e.subject sub
+             JOIN sub.userSubject us
+             JOIN us.user u
+             WHERE e.id = :examId
+               AND u.id = :userId
+            """)
     List<Piece> findByStudyExamIdAndUserId(@Param("examId") Long examId, @Param("userId") Long userId);
+
+//    // 남은 공부 (미완료 + deadline이 지나지 않은 것)
+//    @Query("""
+//        SELECT COUNT(p)
+//        FROM Piece p
+//        JOIN p.study s
+//        JOIN s.exam e
+//        JOIN e.subject subj
+//        JOIN subj.userSubject us
+//        JOIN us.user u
+//        WHERE e.id = :examId
+//          AND u.id = :userId
+//          AND p.isFinished = :isFinished
+//          AND p.isVisible = :isVisible
+//          AND p.deadline >= CURRENT_DATE
+//    """)
+//    int findRemainingCount(
+//            @Param("examId") Long examId,
+//            @Param("userId") Long userId,
+//            @Param("isFinished") boolean isFinished,
+//            @Param("isVisible") boolean isVisible
+//    );
+
+    // 밀린 공부 (isFinished가 false[미완료] + 이고 deadline이 지난 공부)
+//    @Query("""
+//            SELECT COUNT(p)
+//            FROM Piece p
+//            JOIN p.study s
+//            JOIN s.exam e
+//            JOIN e.subject subj
+//            JOIN subj.userSubject us
+//            JOIN us.user u
+//            WHERE u.id = :userId
+//              AND p.isVisible = false
+//              AND p.isFinished = false AND p.deadline < CURRENT_DATE
+//              AND p.study.exam.subject.userSubject.user.id = :userId
+//            """)
+//    int findPendingCount(
+//            @Param("examId") Long examId,
+//            @Param("userId") Long userId,
+//            @Param("isFinished") boolean isFinished,
+//            @Param("isVisible") boolean isVisible
+//    );
+
+    // 남은 공부
+    @Query("""
+    SELECT COUNT(p)
+    FROM Piece p
+    JOIN p.study s
+    JOIN s.exam e
+    JOIN e.subject subj
+    WHERE subj.id = :subjectId
+      AND e.id = :examId
+      AND p.isFinished = false
+      AND p.deadline >= CURRENT_DATE
+""")
+    int findRemainingCount(@Param("subjectId") Long subjectId, @Param("examId") Long examId);
+
+
+    // 밀린 공부
+    @Query("""
+    SELECT COUNT(p)
+    FROM Piece p
+    JOIN p.study s
+    JOIN s.exam e
+    JOIN e.subject subj
+    WHERE subj.id = :subjectId
+      AND e.id = :examId
+      AND p.isFinished = false
+      AND p.deadline < CURRENT_DATE
+""")
+    int findPendingCount(@Param("subjectId") Long subjectId, @Param("examId") Long examId);
+
+
 
 }
 

--- a/src/main/java/com/sopt/bbangzip/domain/piece/service/PieceRetriever.java
+++ b/src/main/java/com/sopt/bbangzip/domain/piece/service/PieceRetriever.java
@@ -93,6 +93,7 @@ public class PieceRetriever {
     Add Pending
      */
 
+    // 중간고사, 기말고사 필터링
     public List<Piece> findByStudyExamIdAndUserId(Long userId, Long examId) {
         return pieceRepository.findByStudyExamIdAndUserId(userId, examId);
     }
@@ -101,4 +102,16 @@ public class PieceRetriever {
     public List<Piece> findAllByIds(List<Long> pieceIds) {
         return pieceRepository.findAllById(pieceIds);
     }
+
+
+    // 남은 공부 가져오기
+    public int findRemainingCount(Long subjectId, Long examId) {
+        return pieceRepository.findRemainingCount(subjectId, examId);
+    }
+
+    // 밀린 공부 가져오기
+    public int findPendingCount(Long subjectId, Long examId) {
+        return pieceRepository.findPendingCount(subjectId, examId);
+    }
+
 }

--- a/src/main/java/com/sopt/bbangzip/domain/subject/api/controller/SubjectController.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/api/controller/SubjectController.java
@@ -5,6 +5,7 @@ import com.sopt.bbangzip.common.dto.ResponseDto;
 import com.sopt.bbangzip.domain.subject.api.dto.request.SubjectCreateDto;
 import com.sopt.bbangzip.domain.subject.api.dto.request.SubjectDeleteDto;
 import com.sopt.bbangzip.domain.subject.api.dto.request.SubjectNameOrMotivationMessageDto;
+import com.sopt.bbangzip.domain.subject.api.dto.response.SubjectResponseDto;
 import com.sopt.bbangzip.domain.subject.service.SubjectService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -49,5 +50,16 @@ public class SubjectController {
 
         subjectService.updateSubjectNameOrMotivationMessage(userId, subjectId, options, subjectNameOrMotivationMessageDto.value());
         return ResponseEntity.noContent().build();
+    }
+
+
+    //  학기 별 과목 목록 필터링
+    @GetMapping("/subjects/filter")
+    public ResponseEntity<SubjectResponseDto> getSubjectsBySemester(
+            @UserId final long userId,
+            @RequestParam final int year,
+            @RequestParam final String semester
+    ) {
+        return ResponseEntity.ok(subjectService.getSubjectsByUserAndSemester(userId, year, semester));
     }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/subject/api/dto/response/SubjectResponseDto.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/api/dto/response/SubjectResponseDto.java
@@ -1,0 +1,28 @@
+package com.sopt.bbangzip.domain.subject.api.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record SubjectResponseDto(
+        int year, // 학년
+        String semester, // 학기
+        List<SubjectDto> subjectList // 과목 리스트
+) {
+    @Builder
+    public record SubjectDto(
+            Long subjectId, // 과목 ID
+            String subjectName, // 과목명
+            List<StudyDto> studyList // 시험 정보 리스트
+    ) {
+        @Builder
+        public record StudyDto(
+                String examName, // 시험 이름
+                int examDDay, // 시험까지 남은 일수
+                int pendingCount, // 밀린 공부 개수
+                int remainingCount // 남은 공부 개수
+        ) {}
+    }
+}
+

--- a/src/main/java/com/sopt/bbangzip/domain/subject/repository/SubjectRepository.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/repository/SubjectRepository.java
@@ -4,6 +4,8 @@ import com.sopt.bbangzip.domain.subject.entity.Subject;
 import com.sopt.bbangzip.domain.user.entity.User;
 import com.sopt.bbangzip.domain.userSubject.entity.UserSubject;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -14,10 +16,26 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
 
     //  UserSubject와 SubjectName으로 Subject 존재 여부 확인
     boolean existsByUserSubjectAndSubjectName(UserSubject userSubject, String subjectName);
+
     // 특정 UserSubject ID와 과목 ID로 과목 조회
     List<Subject> findByIdInAndUserSubjectId(List<Long> subjectIds, Long userSubjectId);
 
     Optional<Subject> findById(Long id);
 
     Optional<Subject> findByUserSubject_UserIdAndIdAndSubjectName(Long userId, Long subjectId, String subjectName);
+
+    // 학기별 과목 목록 조회
+    @Query("""
+            SELECT s
+            FROM Subject s
+            JOIN s.userSubject us
+            WHERE us.user.id = :userId
+              AND us.year = :year
+              AND us.semester = :semester
+           """)
+    List<Subject> findSubjectsByUserAndSemester(
+            @Param("userId") Long userId,
+            @Param("year") int year,
+            @Param("semester") String semester
+    );
 }

--- a/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectRetriever.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectRetriever.java
@@ -49,4 +49,17 @@ public class SubjectRetriever {
         return subjectRepository.findByUserSubject_UserIdAndIdAndSubjectName(userId, subjectId, subjectName)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_SUBJECT));
     }
+
+    /**
+     * 사용자와 학기 정보에 따른 과목 조회
+     *
+     * @param userId 사용자 ID
+     * @param year 학년
+     * @param semester 학기
+     * @return 과목 목록
+     */
+    public List<Subject> findSubjectsByUserAndSemester(Long userId, int year, String semester) {
+        return subjectRepository.findSubjectsByUserAndSemester(userId, year, semester);
+    }
+
 }

--- a/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectService.java
@@ -3,9 +3,13 @@ package com.sopt.bbangzip.domain.subject.service;
 import com.sopt.bbangzip.common.exception.base.DuplicateSubjectException;
 import com.sopt.bbangzip.common.exception.base.InvalidOptionsException;
 import com.sopt.bbangzip.common.exception.code.ErrorCode;
+import com.sopt.bbangzip.domain.exam.entity.Exam;
+import com.sopt.bbangzip.domain.piece.service.PieceRetriever;
 import com.sopt.bbangzip.domain.subject.api.dto.request.SubjectCreateDto;
 import com.sopt.bbangzip.domain.subject.api.dto.request.SubjectDeleteDto;
+import com.sopt.bbangzip.domain.subject.api.dto.response.SubjectResponseDto;
 import com.sopt.bbangzip.domain.subject.entity.Subject;
+import com.sopt.bbangzip.domain.subject.repository.SubjectRepository;
 import com.sopt.bbangzip.domain.user.entity.User;
 import com.sopt.bbangzip.domain.user.service.UserRetriever;
 import com.sopt.bbangzip.domain.userSubject.entity.UserSubject;
@@ -16,7 +20,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -26,6 +33,7 @@ public class SubjectService {
     private final UserRetriever userRetriever;
 
     private final SubjectRetriever subjectRetriever;
+    private final PieceRetriever pieceRetriever;
     private final SubjectSaver subjectSaver;
     private final SubjectRemover subjectRemover;
 
@@ -79,5 +87,56 @@ public class SubjectService {
             case "motivationMessage" -> subjectUpdater.updateMotivationMessage(subject, value);
             default -> throw new InvalidOptionsException(ErrorCode.INVALID_OPTION);
         }
+    }
+
+    /**
+     * 사용자와 학기 정보에 따른 과목 조회
+     *
+     * @param userId
+     * @param year
+     * @param semester
+     * @return SubjectResponseDto - 사용자와 학기에 해당하는 과목 정보와 시험별 공부 현황(남은 공부, 밀린 공부)을 포함한 응답 객체
+     */
+    public SubjectResponseDto getSubjectsByUserAndSemester(Long userId, int year, String semester) {
+        // 사용자 검증
+        userRetriever.findByUserId(userId);
+
+        // 학기별 과목 조회
+        List<Subject> subjects = subjectRetriever.findSubjectsByUserAndSemester(userId, year, semester);
+
+        // Subject 리스트 생성
+        List<SubjectResponseDto.SubjectDto> subjectList = subjects.stream()
+                .map(subject -> new SubjectResponseDto.SubjectDto(
+                        subject.getId(),
+                        subject.getSubjectName(),
+                        subject.getExams().stream()
+                                .map(exam -> mapExamToStudyDto(subject.getId(), exam)) // subjectId 전달
+                                .collect(Collectors.toList())
+                ))
+                .collect(Collectors.toList());
+
+        return new SubjectResponseDto(year, semester, subjectList);
+    }
+
+    /**
+     * Exam 객체를 StudyDto로 매핑
+     *
+     * @param subjectId
+     * @param exam
+     * @return StudyDto - 시험 이름, D-Day, 밀린 공부 개수, 남은 공부 개수를 포함한 DTO
+     */
+    private SubjectResponseDto.SubjectDto.StudyDto mapExamToStudyDto(Long subjectId, Exam exam) {
+        int dDay = (int) ChronoUnit.DAYS.between(LocalDate.now(), exam.getExamDate());
+
+        // 시험별 남은 공부와 밀린 공부 조회
+        int remainingCount = pieceRetriever.findRemainingCount(subjectId, exam.getId());
+        int pendingCount = pieceRetriever.findPendingCount(subjectId, exam.getId());
+
+        return new SubjectResponseDto.SubjectDto.StudyDto(
+                exam.getExamName(),
+                dDay,
+                pendingCount,
+                remainingCount
+        );
     }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/userSubject/entity/UserSubject.java
+++ b/src/main/java/com/sopt/bbangzip/domain/userSubject/entity/UserSubject.java
@@ -21,6 +21,7 @@ public class UserSubject {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
     private User user;
 
     @Column(name = UserSubjectTableConstants.COLUMN_YEAR, nullable = false)


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #40 

## Work Description ✏️

사용자가 선택한 학기에 해당하는 과목 목록을 필터링하여 반환하는 API입니다. 

과목 정보에는 과목명, 시험 정보, 등이 포함됩니다.

![image](https://github.com/user-attachments/assets/a0f1fccc-7e46-4b52-9036-056947b5a849)


## Trouble Shooting ⚽️

완전 처음에 할 때는 한 번에 처리하려고 쿼리를 몽땅 처리했었는데 서팟짱님과의 가정방문을 통해 인사이트를 얻고
쿼리를 쪼개서 사용했어요 !! 덕분에 잘 돌아가는 것 같습니다

그리고 기획적인 부분에서 헷갈리는 것이 있어서 처음에 잘못 구현했어요 ㅠㅠ 

덕분에 기디 사장님과와의 회의를 통해 헷갈리는 부분 확정짓고 수정해서 개발 진행했습니다 !

![image](https://github.com/user-attachments/assets/b20869b9-73d7-402d-9e10-5bb92d8b3d93)


## To Reviewers 📢
기획적인 부분이 헷갈려서 여러 번 기디와 회의하고 수정하다보니 잘못된 부분이 있을 수도 있을 것 같아요 ㅠ
혹시 고쳐야 할 게 있다면 알려주세요 ! 
더 자세한 내용은 트러블슈팅에 나중에 정리하겠습니다 ㅎㅎ (시간이 된다면 이걸로 트슈 쓰고 싶네요)

++ PieceRepository 부분에서 남은 공부와 밀린 공부 추가하는 로직에 유저 빼먹었네요 ! 해당 부분 수정해서 다음 피알에 같이 올릴게요
