### PR TITLE
✏️ [fix] #87 공부(교재) 추가하기 API 에서 뱃지 반환 로직 추가

### DIFF
--- a/src/main/java/com/sopt/bbangzip/common/constants/entity/UserTableConstants.java
+++ b/src/main/java/com/sopt/bbangzip/common/constants/entity/UserTableConstants.java
@@ -20,6 +20,7 @@ public class UserTableConstants {
     public static final String COLUMN_FIRST_TODAY_TASKS_COMPLETED_AT = "first_today_tasks_completed_at";
     public static final String COLUMN_TODAY_STUDY_COMPLETE_COUNT = "today_study_complete_count";
     public static final String COLUMN_LAST_STUDY_COMPLETED_DATE = "last_study_completed_date";
+    public static final String COLUMN_FIRST_CREATE_STUDY_COUNT = "first_create_study_count";
     public static final String COLUMN_HAS_MASS_BAKING_BREAD_BADGE = "has_mass_baking_bread_badge";
     public static final String COLUMN_HAS_PREPARING_OPENING_BAKERY = "has_preparing_opening_bakery";
 }

--- a/src/main/java/com/sopt/bbangzip/common/constants/entity/UserTableConstants.java
+++ b/src/main/java/com/sopt/bbangzip/common/constants/entity/UserTableConstants.java
@@ -1,7 +1,10 @@
 package com.sopt.bbangzip.common.constants.entity;
 
 public class UserTableConstants {
+    // 테이블 이름
     public static final String TABLE_USER = "user";
+
+    // 컬럼 이름
     public static final String COLUMN_ID = "id";
     public static final String COLUMN_PLATFORM_USER_ID = "platform_user_id";
     public static final String COLUMN_PLATFORM = "platform";
@@ -11,6 +14,8 @@ public class UserTableConstants {
     public static final String COLUMN_USER_LEVEL = "user_level";
     public static final String COLUMN_CREATED_AT = "created_at";
     public static final String COLUMN_UPDATED_AT = "updated_at";
+
+    // 뱃지 관련 컬럼
     public static final String COLUMN_FIRST_STUDY_COMPLETED_AT = "first_study_completed_at";
     public static final String COLUMN_FIRST_TODAY_TASKS_COMPLETED_AT = "first_today_tasks_completed_at";
     public static final String COLUMN_TODAY_STUDY_COMPLETE_COUNT = "today_study_complete_count";

--- a/src/main/java/com/sopt/bbangzip/domain/badge/api/dto/response/BadgeResponse.java
+++ b/src/main/java/com/sopt/bbangzip/domain/badge/api/dto/response/BadgeResponse.java
@@ -1,7 +1,10 @@
 package com.sopt.bbangzip.domain.badge.api.dto.response;
 
+import lombok.Builder;
+
 import java.util.List;
 
+@Builder
 public record BadgeResponse(
         String badgeName,
         String badgeImage,

--- a/src/main/java/com/sopt/bbangzip/domain/badge/entity/Badge.java
+++ b/src/main/java/com/sopt/bbangzip/domain/badge/entity/Badge.java
@@ -1,4 +1,4 @@
-package com.sopt.bbangzip.domain.badge;
+package com.sopt.bbangzip.domain.badge.entity;
 
 import com.sopt.bbangzip.domain.user.entity.User;
 

--- a/src/main/java/com/sopt/bbangzip/domain/badge/entity/BadgeCondition.java
+++ b/src/main/java/com/sopt/bbangzip/domain/badge/entity/BadgeCondition.java
@@ -1,4 +1,4 @@
-package com.sopt.bbangzip.domain.badge;
+package com.sopt.bbangzip.domain.badge.entity;
 
 import com.sopt.bbangzip.domain.user.entity.User;
 

--- a/src/main/java/com/sopt/bbangzip/domain/badge/entity/MassBakingBreadBadge.java
+++ b/src/main/java/com/sopt/bbangzip/domain/badge/entity/MassBakingBreadBadge.java
@@ -1,4 +1,4 @@
-package com.sopt.bbangzip.domain.badge;
+package com.sopt.bbangzip.domain.badge.entity;
 
 import com.sopt.bbangzip.domain.user.entity.User;
 import org.springframework.stereotype.Component;
@@ -6,36 +6,36 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 @Component
-public class StartBakingBreadBadge implements Badge{
+public class MassBakingBreadBadge implements Badge{
     @Override
     public BadgeCondition getCondition(){
-        // 맨 처음 학습을 완료한 필드가 아직 null 이면 해당 뱃지 획득 가능
-        return user -> user.getFirstStudyCompletedAt() == null && user.getTodayStudyCompleteCount() > 0;
+        return user -> user.getTodayStudyCompleteCount() >= 3;
     }
 
     @Override
     public String getName() {
-        return "빵 굽기 시작";
+        return "빵 대량 생산";
     }
 
     @Override
     public int getReward() {
-        return 100;
+        return 50;
     }
 
     @Override
     public List<String> getHashTags() {
-        return List.of("#오늘은 무슨 빵을 구울까", "#빵 냄새 솔솔", "#노릇노릇");
+        return List.of("#사장님은 열일 중", "#오늘 빵 몇 개 구울 거야", "#백만 개");
     }
 
     @Override
     public String getImage() {
-        return "https://example.com/images/1";
+        return "https://example.com/images/3";
     }
+
 
     @Override
     public String getCategory() {
-        return "시작이 빵이다";
+        return "미룬이 탈출"; // 뱃지 카테고리
     }
 
     @Override
@@ -46,6 +46,6 @@ public class StartBakingBreadBadge implements Badge{
 
     @Override
     public String getAchievementCondition(){
-        return "최초로 '학습완료'를 수행한 경우";
+        return "24시간 내 '학습 완료'를 3회 완료한 경우";
     }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/badge/entity/PreparingOpenBakery.java
+++ b/src/main/java/com/sopt/bbangzip/domain/badge/entity/PreparingOpenBakery.java
@@ -1,0 +1,49 @@
+package com.sopt.bbangzip.domain.badge.entity;
+
+import com.sopt.bbangzip.domain.user.entity.User;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class PreparingOpenBakery implements Badge {
+    @Override
+    public BadgeCondition getCondition() {
+        return user -> user.getHasPreparingOpeningBakery() != null && user.getFirstCreateStudyCount() > 0; // '최초 학습 완료'를 수행한 경우
+    }
+
+    @Override
+    public String getName() {
+        return "빵집 오픈 준비 중";
+    }
+
+    @Override
+    public int getReward() {
+        return 50;
+    }
+
+    @Override
+    public List<String> getHashTags() {
+        return List.of("#오늘은 무슨 빵을 구울까", "#빵 냄새 솔솔", "#노릇노릇");
+    }
+
+    @Override
+    public String getImage() {
+        return "https://example.com/images/4";
+    }
+
+    @Override
+    public String getCategory() {
+        return "시작이 빵이다";
+    }
+
+    @Override
+    public Boolean isLocked(User user) {
+        return !getCondition().isEligible(user);
+    }
+
+    @Override
+    public String getAchievementCondition() {
+        return "최초로 '학습 완료'를 수행한 경우";
+    }
+}

--- a/src/main/java/com/sopt/bbangzip/domain/badge/entity/PreparingOpenBakery.java
+++ b/src/main/java/com/sopt/bbangzip/domain/badge/entity/PreparingOpenBakery.java
@@ -9,7 +9,7 @@ import java.util.List;
 public class PreparingOpenBakery implements Badge {
     @Override
     public BadgeCondition getCondition() {
-        return user -> user.getHasPreparingOpeningBakery() != null && user.getFirstCreateStudyCount() > 0; // '최초 학습 완료'를 수행한 경우
+        return user -> user.getFirstCreateStudyCount() == 0; // Study 생성 횟수가 0인 경우
     }
 
     @Override

--- a/src/main/java/com/sopt/bbangzip/domain/badge/entity/StartBakingBreadBadge.java
+++ b/src/main/java/com/sopt/bbangzip/domain/badge/entity/StartBakingBreadBadge.java
@@ -1,4 +1,4 @@
-package com.sopt.bbangzip.domain.badge;
+package com.sopt.bbangzip.domain.badge.entity;
 
 import com.sopt.bbangzip.domain.user.entity.User;
 import org.springframework.stereotype.Component;
@@ -6,36 +6,36 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 @Component
-public class MassBakingBreadBadge implements Badge{
+public class StartBakingBreadBadge implements Badge{
     @Override
     public BadgeCondition getCondition(){
-        return user -> user.getTodayStudyCompleteCount() >= 3;
+        // 맨 처음 학습을 완료한 필드가 아직 null 이면 해당 뱃지 획득 가능
+        return user -> user.getFirstStudyCompletedAt() == null && user.getTodayStudyCompleteCount() > 0;
     }
 
     @Override
     public String getName() {
-        return "빵 대량 생산";
+        return "빵 굽기 시작";
     }
 
     @Override
     public int getReward() {
-        return 50;
+        return 100;
     }
 
     @Override
     public List<String> getHashTags() {
-        return List.of("#사장님은 열일 중", "#오늘 빵 몇 개 구울 거야", "#백만 개");
+        return List.of("#오늘은 무슨 빵을 구울까", "#빵 냄새 솔솔", "#노릇노릇");
     }
 
     @Override
     public String getImage() {
-        return "https://example.com/images/3";
+        return "https://example.com/images/1";
     }
-
 
     @Override
     public String getCategory() {
-        return "미룬이 탈출"; // 뱃지 카테고리
+        return "시작이 빵이다";
     }
 
     @Override
@@ -46,6 +46,6 @@ public class MassBakingBreadBadge implements Badge{
 
     @Override
     public String getAchievementCondition(){
-        return "24시간 내 '학습 완료'를 3회 완료한 경우";
+        return "최초로 '학습완료'를 수행한 경우";
     }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/badge/entity/TodayBreadSoldOutBadge.java
+++ b/src/main/java/com/sopt/bbangzip/domain/badge/entity/TodayBreadSoldOutBadge.java
@@ -1,4 +1,4 @@
-package com.sopt.bbangzip.domain.badge;
+package com.sopt.bbangzip.domain.badge.entity;
 
 import com.sopt.bbangzip.domain.piece.service.PieceRetriever;
 import com.sopt.bbangzip.domain.user.entity.User;

--- a/src/main/java/com/sopt/bbangzip/domain/badge/service/BadgeRetriever.java
+++ b/src/main/java/com/sopt/bbangzip/domain/badge/service/BadgeRetriever.java
@@ -1,5 +1,6 @@
-package com.sopt.bbangzip.domain.badge;
+package com.sopt.bbangzip.domain.badge.service;
 
+import com.sopt.bbangzip.domain.badge.entity.Badge;
 import org.springframework.stereotype.Component;
 
 import java.util.List;

--- a/src/main/java/com/sopt/bbangzip/domain/badge/service/BadgeService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/badge/service/BadgeService.java
@@ -2,13 +2,14 @@ package com.sopt.bbangzip.domain.badge.service;
 
 import com.sopt.bbangzip.common.exception.base.NotFoundException;
 import com.sopt.bbangzip.common.exception.code.ErrorCode;
-import com.sopt.bbangzip.domain.badge.Badge;
-import com.sopt.bbangzip.domain.badge.BadgeCondition;
+import com.sopt.bbangzip.domain.badge.entity.Badge;
+import com.sopt.bbangzip.domain.badge.entity.BadgeCondition;
 import com.sopt.bbangzip.domain.badge.api.dto.response.BadgeDetailResponse;
 import com.sopt.bbangzip.domain.badge.api.dto.response.BadgeListResponse;
 import com.sopt.bbangzip.domain.badge.api.dto.response.BadgeResponse;
 import com.sopt.bbangzip.domain.piece.service.PieceRetriever;
 import com.sopt.bbangzip.domain.user.entity.User;
+import com.sopt.bbangzip.domain.user.repository.UserRepository;
 import com.sopt.bbangzip.domain.user.service.UserLevelCalculator;
 import com.sopt.bbangzip.domain.user.service.UserRetriever;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class BadgeService {
 
+    private final UserRetriever userRetriever;
+
     /**
      * - 모든 뱃지의 목록 관리
      * - 사용자에게 조건에 맞는 뱃지 지급
@@ -32,8 +35,8 @@ public class BadgeService {
 
     private final List<Badge> badges;
     private final PieceRetriever pieceRetriever;
-    private final UserRetriever userRetriever;
     private final UserLevelCalculator userLevelCalculator;
+    private final UserRepository userRepository;
 
     /**
      * 조건에 맞는 모든 뱃지를 반환
@@ -68,6 +71,7 @@ public class BadgeService {
             case "빵 굽기 시작" -> user.getFirstStudyCompletedAt() != null;
             case "오늘의 빵 완판" -> user.getAllTasksCompletedAt() != null;
             case "빵 대량 생산" -> user.getHasMassBakingBreadBadge() != null;
+            case "빵집 오픈 준비 중" -> user.getHasPreparingOpeningBakery() != null;
             default -> false;
         };
     }
@@ -83,8 +87,10 @@ public class BadgeService {
             case "빵 굽기 시작" -> user.markFirstStudyComplete();
             case "오늘의 빵 완판" -> user.markFirstTodayTasksCompletedAt();
             case "빵 대량 생산" -> user.markHasMassBakingBreadBadge();
+            case "빵집 오픈 준비 중" -> user.markHasPreparingOpeningBakery();
             default -> throw new IllegalArgumentException();
         }
+        userRepository.save(user);
         log.info(badge.getName() + "뱃지를 획득하였습니다!");
     }
 
@@ -117,6 +123,8 @@ public class BadgeService {
                 return user.getAllTasksCompletedAt() == null;
             case "빵 대량 생산":
                 return user.getHasMassBakingBreadBadge() == null;
+            case "빵집 오픈 준비 중":
+                return user.getHasPreparingOpeningBakery() == null;
             default:
                 return true;
         }

--- a/src/main/java/com/sopt/bbangzip/domain/piece/entity/Piece.java
+++ b/src/main/java/com/sopt/bbangzip/domain/piece/entity/Piece.java
@@ -11,7 +11,6 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
 @Entity
 @Getter
@@ -66,21 +65,14 @@ public class Piece {
         this.updatedAt = LocalDateTime.now();
     }
 
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy년MM월dd일");
-
     @Builder
-    public Piece(Study study, int startPage, int finishPage, String deadline) {
+    public Piece(Study study, int startPage, int finishPage, LocalDate deadline) {
         this.study = study;
         this.startPage = startPage;
         this.finishPage = finishPage;
         this.pageAmount = finishPage - startPage + 1;
-        this.deadline = parseStringToLocalDate(deadline);
+        this.deadline = deadline;
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
-    }
-
-    // String 값을 LocalDate로 변환
-    private LocalDate parseStringToLocalDate(String date) {
-        return LocalDate.parse(date, DATE_FORMATTER);
     }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/study/api/controller/StudyController.java
+++ b/src/main/java/com/sopt/bbangzip/domain/study/api/controller/StudyController.java
@@ -2,14 +2,15 @@ package com.sopt.bbangzip.domain.study.api.controller;
 
 import com.sopt.bbangzip.common.annotation.UserId;
 import com.sopt.bbangzip.common.dto.ResponseDto;
+import com.sopt.bbangzip.domain.badge.api.dto.response.BadgeResponse;
 import com.sopt.bbangzip.domain.study.api.dto.request.StudyCreateRequestDto;
+import com.sopt.bbangzip.domain.study.api.dto.response.CreateStudyResponse;
 import com.sopt.bbangzip.domain.study.service.StudyService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -18,11 +19,11 @@ public class StudyController {
     private final StudyService studyService;
 
     @PostMapping("/studies")
-    public ResponseEntity<ResponseDto<List<Object>>> createStudy(
+    public ResponseEntity<CreateStudyResponse> createStudy(
             @UserId final long userId,
             @RequestBody @Valid final StudyCreateRequestDto studyCreateRequestDto
     ) {
-        studyService.createStudy(userId, studyCreateRequestDto);
-        return ResponseEntity.ok(ResponseDto.success(null));
+        CreateStudyResponse response = studyService.createStudy(userId, studyCreateRequestDto);
+        return ResponseEntity.ok(ResponseDto.success(response).data());
     }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/study/api/dto/response/CreateStudyResponse.java
+++ b/src/main/java/com/sopt/bbangzip/domain/study/api/dto/response/CreateStudyResponse.java
@@ -1,0 +1,12 @@
+package com.sopt.bbangzip.domain.study.api.dto.response;
+
+import com.sopt.bbangzip.domain.badge.api.dto.response.BadgeResponse;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record CreateStudyResponse(
+        List<BadgeResponse> badges
+) {
+}

--- a/src/main/java/com/sopt/bbangzip/domain/study/service/StudyService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/study/service/StudyService.java
@@ -1,40 +1,55 @@
 package com.sopt.bbangzip.domain.study.service;
 
+import com.sopt.bbangzip.domain.badge.api.dto.response.BadgeResponse;
+import com.sopt.bbangzip.domain.badge.service.BadgeService;
 import com.sopt.bbangzip.domain.exam.entity.Exam;
 import com.sopt.bbangzip.domain.exam.service.ExamSaver;
 import com.sopt.bbangzip.domain.piece.entity.Piece;
 import com.sopt.bbangzip.domain.piece.service.PieceSaver;
 import com.sopt.bbangzip.domain.study.api.dto.request.StudyCreateRequestDto;
 
+import com.sopt.bbangzip.domain.study.api.dto.response.CreateStudyResponse;
 import com.sopt.bbangzip.domain.study.entity.Study;
 import com.sopt.bbangzip.domain.subject.entity.Subject;
 import com.sopt.bbangzip.domain.subject.service.SubjectRetriever;
+import com.sopt.bbangzip.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class StudyService {
     private final PieceSaver pieceSaver;
     private final ExamSaver examSaver;
     private final StudySaver studySaver;
     private final SubjectRetriever subjectRetriever;
+    private final BadgeService badgeService;
 
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     @Transactional
-    public void createStudy(Long userId, StudyCreateRequestDto studyCreateRequestDto) {
-        Subject subject = subjectRetriever.findById(studyCreateRequestDto.subjectId());
+    public CreateStudyResponse createStudy(Long userId, StudyCreateRequestDto studyCreateRequestDto) {
+        Subject subject = subjectRetriever.findByUserIdAndSubjectId(userId, studyCreateRequestDto.subjectId());
+
+        LocalDate examDate;
+        try {
+            examDate = LocalDate.parse(studyCreateRequestDto.examDate(), DATE_FORMATTER);
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException("Invalid date format. Expected format: yyyy-MM-dd");
+        }
 
         Exam exam = Exam.builder()
                 .examName(studyCreateRequestDto.examName())
-                .examDate(parseStringToLocalDate(studyCreateRequestDto.examDate()))
+                .examDate(examDate)
                 .subject(subject)
                 .build();
         examSaver.save(exam);
@@ -46,20 +61,24 @@ public class StudyService {
         studySaver.save(study);
 
         List<Piece> pieces = studyCreateRequestDto.pieceList().stream()
-                .map(pieceDto -> Piece.builder()
-                        .study(study)
-                        .startPage(pieceDto.startPage())
-                        .finishPage(pieceDto.finishPage())
-                        .deadline(pieceDto.deadline())
-                        .build()
-                )
+                .map(pieceDto -> {
+                    LocalDate deadline = LocalDate.parse(pieceDto.deadline(), DATE_FORMATTER);
+                    return Piece.builder()
+                            .study(study)
+                            .startPage(pieceDto.startPage())
+                            .finishPage(pieceDto.finishPage())
+                            .deadline(deadline)
+                            .build();
+                })
                 .collect(Collectors.toList());
-
         pieceSaver.saveAll(pieces);
-    }
 
-    // 날짜 String을 LocalDate로 변환
-    private LocalDate parseStringToLocalDate(String date) {
-        return LocalDate.parse(date, DATE_FORMATTER);
+        // 조건 충족 시 뱃지 부여
+        User user = subject.getUserSubject().getUser();
+        List<BadgeResponse> badges = badgeService.getAllEligibleBadges(user);
+
+        return CreateStudyResponse.builder()
+                .badges(badges)
+                .build();
     }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/subject/repository/SubjectRepository.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/repository/SubjectRepository.java
@@ -19,5 +19,6 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
 
     Optional<Subject> findById(Long id);
 
-    Optional<Subject> findByUserSubject_UserIdAndIdAndSubjectName(Long userId, Long subjectId, String subjectName);
+    // 유저 ID와 과목 ID로 Subject 조회
+    Optional<Subject> findByUserSubject_UserIdAndId(Long userId, Long subjectId);
 }

--- a/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectRetriever.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectRetriever.java
@@ -44,9 +44,9 @@ public class SubjectRetriever {
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_SUBJECT));
     }
 
-    // UserId 과목 ID, 과목 이름으로 과목을 조회하는 메서드
-    public Subject findByUserIdAndSubjectName(Long userId, Long subjectId, String subjectName) {
-        return subjectRepository.findByUserSubject_UserIdAndIdAndSubjectName(userId, subjectId, subjectName)
+    // 유저 ID와 과목 ID를 기반으로 과목 조회
+    public Subject findByUserIdAndSubjectId(Long userId, Long subjectId) {
+        return subjectRepository.findByUserSubject_UserIdAndId(userId, subjectId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_SUBJECT));
     }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/user/entity/User.java
+++ b/src/main/java/com/sopt/bbangzip/domain/user/entity/User.java
@@ -84,6 +84,10 @@ public class User {
     @Column(name = UserTableConstants.COLUMN_HAS_PREPARING_OPENING_BAKERY)
     private LocalDateTime hasPreparingOpeningBakery = null; // 빵집 오픈 준비중 뱃지 획득 여부
 
+    @SuppressWarnings("FieldMayBeFinal")
+    @Column(name = UserTableConstants.COLUMN_FIRST_CREATE_STUDY_COUNT, nullable = false)
+    private int firstCreateStudyCount = 0;
+
 
     @SuppressWarnings("FieldMayBeFinal")
     @Column(name = UserTableConstants.COLUMN_TODAY_STUDY_COMPLETE_COUNT, nullable = false)

--- a/src/main/java/com/sopt/bbangzip/domain/user/entity/User.java
+++ b/src/main/java/com/sopt/bbangzip/domain/user/entity/User.java
@@ -102,7 +102,7 @@ public class User {
         }
     }
 
-    public void markFirstTodayTasksCompletedAt() { // 맨 처름으로 '오늘 할 일'을 모두 완료 (오늘의 빵 완판)
+    public void markFirstTodayTasksCompletedAt() { // 맨 처음으로 '오늘 할 일'을 모두 완료 (오늘의 빵 완판)
         if (this.allTasksCompletedAt == null) {
             this.allTasksCompletedAt = LocalDateTime.now();
             this.point += 200;
@@ -116,7 +116,7 @@ public class User {
         }
     }
 
-    public void markHasPreparingOpeningBakery(){
+    public void markHasPreparingOpeningBakery(){ // 맨 처음으로 '공부할 내용'을 추가 (빵집 오픈 준비 중)
         if (this.hasPreparingOpeningBakery == null) {
             this.hasPreparingOpeningBakery = LocalDateTime.now();
             this.point +=50;


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #79  
- closes #87 

## Work Description ✏️
<!-- 작업 내용을 간단히 소개주세요 -->
- 공부 추가하기 API 에서 유저가 최초로 공부(교재)를 추가하면 '빵집 오픈 준비 중' 뱃지를 얻게끔 로직을 수정했습니다.
- subject 를 userId 에 해당하는 아이로 찾아오도록 쿼리문 수정했습니다.


## Trouble Shooting ⚽️
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->
처음에는 뱃지가 획득되어야 하는 상황임에도 hasPreparingOpeningBakery 필드가 업그레이드 되지 않는 문제가 발생했습니다.
원인을 분석해보니 ..

1. 처음 getCondition 메서드에선 (뱃지를 획득하기 위해 필요한 조건)
- PreparingOpenBakery 뱃지의 획득 조건으로 user.getHasPreparingOpeningBakery() != null인지 여부를 확인했습니다.
2. isBadgeAlreadyAwarded 메서드에선 (뱃지 이미 획득했었는지 판단하는 로직)
- 뱃지가 이미 부여되었는지 여부를 판단하기 위해 동일한 필드 (user.getHasPreparingOpeningBakery())를 확인했습니다.
3. 그래서 문제점 ..
- getCondition에서 사용한 조건과 isBadgeAlreadyAwarded의 조건이 같아서 문제가 발생했습니다.
-> 아직 markHasPreparingOpeningBakery가 호출되기 전이라면 뱃지를 부여할 수 없고, 호출된 후에는 뱃지가 이미 수여된 것으로 간주될 수 있기에 ..

그래서 user.getFirstCreateStudyCount() == 0; // Study 생성 횟수가 0인 경우
조건으로 획득 조건을 판단했습니다.

[결과 확인]
<img width="850" alt="image" src="https://github.com/user-attachments/assets/8a60fc81-bf6e-40b8-853d-da006c034f05" />



## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
오전 7시 52분. 포기하지 않았기에 성공.
