### PR TITLE
✏️ [fix] #102 user 을 users 로 테이블명 업데이트

### DIFF
--- a/src/main/java/com/sopt/bbangzip/common/constants/entity/UserTableConstants.java
+++ b/src/main/java/com/sopt/bbangzip/common/constants/entity/UserTableConstants.java
@@ -2,7 +2,7 @@ package com.sopt.bbangzip.common.constants.entity;
 
 public class UserTableConstants {
     // 테이블 이름
-    public static final String TABLE_USER = "user";
+    public static final String TABLE_USER = "users";
 
     // 컬럼 이름
     public static final String COLUMN_ID = "id";


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #102 

## Work Description ✏️
<!-- 작업 내용을 간단히 소개주세요 -->
기존에 쓰던 mysql 데이터베이스 알 수 없는 연결 문제로 인해
AWS 에서 ec2, rds 를 postgresql 로 모두 새로 세팅했습니다.

postgresql 에선 테이블명으로 user 을 쓸 수 없으므로, users 로 필드명을 바꿨습니다.
