### PR TITLE
✏️ [fix] #90 마이페이지에서 레벨 별 이름 및 레벨 메세지 추가

### DIFF
--- a/src/main/java/com/sopt/bbangzip/domain/user/api/controller/UserController.java
+++ b/src/main/java/com/sopt/bbangzip/domain/user/api/controller/UserController.java
@@ -1,7 +1,7 @@
 package com.sopt.bbangzip.domain.user.api.controller;
 
 import com.sopt.bbangzip.common.annotation.UserId;
-import com.sopt.bbangzip.domain.user.api.dto.UserLevelResponseDto;
+import com.sopt.bbangzip.domain.user.api.dto.response.MypageDto;
 import com.sopt.bbangzip.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,11 +16,11 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("/mypage")
-    public ResponseEntity<UserLevelResponseDto> getMyPage(
+    public ResponseEntity<MypageDto> getMyPage(
             @UserId final Long userId
     ) {
         // 마이페이지 조회 시 유저 레벨 업데이트
-        UserLevelResponseDto responseDto = userService.updateAndGetUserLevelStatus(userId);
+        MypageDto responseDto = userService.updateAndGetUserLevelStatus(userId);
         return ResponseEntity.ok(responseDto);
     }
 

--- a/src/main/java/com/sopt/bbangzip/domain/user/api/dto/UserLevelResponseDto.java
+++ b/src/main/java/com/sopt/bbangzip/domain/user/api/dto/UserLevelResponseDto.java
@@ -1,8 +1,0 @@
-package com.sopt.bbangzip.domain.user.api.dto;
-
-public record UserLevelResponseDto(
-        int level,       // 사용자 레벨
-        int badgeCounts, // 뱃지 개수
-        int reward,       // 보상 포인트
-        int maxReward      // 현재 레벨의 최대 포인트
-) {}

--- a/src/main/java/com/sopt/bbangzip/domain/user/api/dto/response/MypageDto.java
+++ b/src/main/java/com/sopt/bbangzip/domain/user/api/dto/response/MypageDto.java
@@ -1,0 +1,18 @@
+package com.sopt.bbangzip.domain.user.api.dto.response;
+
+public record MypageDto(
+        int level,       // 사용자 레벨
+        int badgeCounts, // 뱃지 개수
+        int reward,       // 보상 포인트
+        int maxReward,      // 현재 레벨의 최대 포인트
+        java.util.List<LevelDetail> levelDetails) {
+    public record LevelDetail(
+            int level,               // 레벨
+            String levelName,
+            String levelDescription, // 레벨 설명
+            String levelImage,       // 레벨 이미지 URL
+            boolean levelIsLocked   // 잠금 여부
+    )
+    {}
+}
+

--- a/src/main/java/com/sopt/bbangzip/domain/user/api/dto/response/MypageDto.java
+++ b/src/main/java/com/sopt/bbangzip/domain/user/api/dto/response/MypageDto.java
@@ -1,11 +1,14 @@
 package com.sopt.bbangzip.domain.user.api.dto.response;
 
+import java.util.List;
+
 public record MypageDto(
         int level,       // 사용자 레벨
         int badgeCounts, // 뱃지 개수
         int reward,       // 보상 포인트
         int maxReward,      // 현재 레벨의 최대 포인트
-        java.util.List<LevelDetail> levelDetails) {
+        List<LevelDetail> levelDetails
+) {
     public record LevelDetail(
             int level,               // 레벨
             String levelName,

--- a/src/main/java/com/sopt/bbangzip/domain/user/service/UserService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/user/service/UserService.java
@@ -1,12 +1,15 @@
 package com.sopt.bbangzip.domain.user.service;
 
-import com.sopt.bbangzip.domain.user.api.dto.UserLevelResponseDto;
-import com.sopt.bbangzip.domain.user.entity.User;
+import com.sopt.bbangzip.domain.user.api.dto.response.MypageDto;
 import com.sopt.bbangzip.domain.user.repository.UserRepository;
+import com.sopt.bbangzip.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -18,22 +21,76 @@ public class UserService {
     private final UserRepository userRepository;
 
     @Transactional
-    public UserLevelResponseDto updateAndGetUserLevelStatus(Long userId) {
+    public MypageDto updateAndGetUserLevelStatus(Long userId) {
         User user = userRetriever.findByUserId(userId);
 
-        // 새로운 레벨 및 최대 포인트 계산
+        // 유저의 현재 포인트 기반 레벨 정보 계산
         UserLevelCalculator.LevelInfo levelInfo = userLevelCalculator.calculateLevelInfo(user.getPoint());
 
-        // 유저의 레벨 업데이트
+        // 유저 레벨 업데이트 후 저장
         user.updateUserLevel(levelInfo.getLevel());
         userRepository.save(user);
 
-        // DTO 반환
-        return new UserLevelResponseDto(
+        // 레벨별 상세 정보 생성
+        List<MypageDto.LevelDetail> levelDetails = createLevelDetails(levelInfo.getLevel());
+
+        return new MypageDto(
                 user.getUserLevel(),
                 user.getBadgeCount(),
                 user.getPoint(),
-                levelInfo.getMaxReward()
+                levelInfo.getMaxReward(),
+                levelDetails
         );
     }
+
+    /**
+     * 레벨별 상세 정보 리스트 생성
+     * @param currentLevel  유저의 현재 레벨
+     * @return 레벨 상세 정보 리스트
+     */
+    private List<MypageDto.LevelDetail> createLevelDetails(int currentLevel) {
+        List<MypageDto.LevelDetail> levelDetails = new ArrayList<>();
+
+        for (int level = 1; level <= LEVEL_DETAILS.size(); level++) {
+            LevelDetailData levelDetailData = LEVEL_DETAILS.get(level - 1);
+
+            // 현재 레벨 이하일 경우 잠금 해제
+            boolean isLocked = level > currentLevel;
+
+            levelDetails.add(new MypageDto.LevelDetail(
+                    levelDetailData.level,
+                    levelDetailData.levelName,
+                    levelDetailData.levelDescription,
+                    levelDetailData.levelImage,
+                    isLocked
+            ));
+        }
+
+        return levelDetails;
+    }
+
+
+    /**
+     * 레벨별 상세 정보
+     */
+    private static class LevelDetailData {
+        private final int level;
+        private final String levelName;
+        private final String levelDescription;
+        private final String levelImage;
+
+        public LevelDetailData(int level, String levelName, String levelDescription, String levelImage) {
+            this.level = level;
+            this.levelName = levelName;
+            this.levelDescription = levelDescription;
+            this.levelImage = levelImage;;
+        }
+    }
+
+    // 레벨별 상세 정보를 관리하는 상수 데이터
+    private static final List<LevelDetailData> LEVEL_DETAILS = List.of(
+            new LevelDetailData(1, "허름한 돗자리", "빵집을 시작한 초보 사장님!", "https://example.com/images/level1.png"),
+            new LevelDetailData(2, "평범한 돗자리", "평범한 돗자리를 얻은 사장님!", "https://example.com/images/level2.png"),
+            new LevelDetailData(3, "럭셔리 돗자리", "럭셔리 돗자리를 얻은 사장님!", "https://example.com/images/level3.png")
+    );
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #90

## Work Description ✏️
레벨별 해당하는 레벨 이미지와 레벨 설명도 함께 제공합니다.
![image](https://github.com/user-attachments/assets/e1e9a1ec-2cfa-40e6-be9e-bbaa935953e2)
**[ level 1 일 때 ]**

level1에 해당하는 모든 정보들이 보여지고  `LevelIsLocked` 의 값이 `false` 입니다.
level2에 해당하는 모든 정보들이 보여지고 `LevelIsLocked` 의 값이 `true` 입니다.
level2에 해당하는 모든 정보들이 보여지고  `LevelIsLocked` 의 값이 `true` 입니다.

**[ level 2 일 때 ]**

level1에 해당하는 모든 정보들이 보여지고  `LevelIsLocked` 의 값이 `false` 입니다.
level2에 해당하는 모든 정보들이 보여지고 `LevelIsLocked` 의 값이 `false` 입니다.
level2에 해당하는 모든 정보들이 보여지고  `LevelIsLocked` 의 값이 `true` 입니다.

**[ level 3 일 때 ]**

level1에 해당하는 모든 정보들이 보여지고  `LevelIsLocked` 의 값이 `false` 입니다.
level2에 해당하는 모든 정보들이 보여지고 `LevelIsLocked` 의 값이 `false` 입니다.
level2에 해당하는 모든 정보들이 보여지고  `LevelIsLocked` 의 값이 `false` 입니다.



## Trouble Shooting ⚽️

1. 처음으로 공부조각 완료하기를 체크하면 -> 빵 굽기 시작 뱃지를 얻어야하는데 뱃지 두 개를 부여받는 걸로 나옵니다 ㅎㅎ
![image](https://github.com/user-attachments/assets/73d7a786-9e99-4ef2-af29-9fef454c8bbd)

마이페이지에서 조회했을 때는 빵굽기시작 뱃지만 카운팅 되어서 뱃지 개수는 하나로 반환됩니다.
![image](https://github.com/user-attachments/assets/4d4907b8-0c19-4f01-a657-0ce3dc5ee3ab)
따라서 공부조각 완료 표시를 했을 때 공부교재 추가 했을 때 나와야하는 빵집 오픈 준비중 뱃지가 같이 부여되므로 이 부분 로직 수정해야할 것 같아용 !!

2. 공부교재를 처음으로 추가했을 경우 -> 빵집 오픈 준비중 뱃지를 획득해야합니다. 
![image](https://github.com/user-attachments/assets/a57602c2-950b-43e5-bb8f-1f7c653d46ae)

여기서 빵집 오픈 준비중 뱃지는 잘 획득하나, 마이페이지에서 조회했을 때 얻은 뱃지 개수는 증가되지 않으나 포인트는 증가됩니다.
따라서 빵집 오픈 준비중 뱃지를 획득했을 때 유저의 뱃지 개수가 늘어나는 로직을 추가하면 될 것 같아요 !!


## To Reviewers 📢

해당 API 작업하면서 영주 사장님의 뱃지 로직 관련해서 수정사항이 있는 것 같아요 ! 
리마인드 차원에서 이 피알 트러블 슈팅에 다시 적어두겠습니다 !! 화이팅해보아용 👍 
