### PR TITLE
✏️ [fix] #117 반환 응답값 수정

### DIFF
--- a/src/main/java/com/sopt/bbangzip/domain/piece/api/dto/response/MarkDoneResponse.java
+++ b/src/main/java/com/sopt/bbangzip/domain/piece/api/dto/response/MarkDoneResponse.java
@@ -7,7 +7,5 @@ import java.util.List;
 
 @Builder
 public record MarkDoneResponse(
-        int todayCounts,
-        int completeCounts,
         List<BadgeResponse> badges
 ) {}

--- a/src/main/java/com/sopt/bbangzip/domain/piece/service/PieceService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/piece/service/PieceService.java
@@ -67,15 +67,8 @@ public class PieceService {
         // 얻은 뱃지가 있다면 뱃지 반환하고, 없다면 null 이 반환됨
         List<BadgeResponse> newlyAwardedBadges = pieceUpdater.updateStatusDone(piece, isFinishedDto, user);
 
-        // 3. 오늘 남은 총 공부 개수 확인
-        int todayCounts = pieceRetriever.countUnfinishedTodayPieces(userId);
-        // 3. 오늘 완료한 총 공부 개수 확인
-        int completeCounts = pieceRetriever.countFinishedTodayPieces(userId);
-
         // 뱃지 획득 여부와 상관없이 응답 생성
         return MarkDoneResponse.builder()
-                .todayCounts(todayCounts)
-                .completeCounts(completeCounts)
                 .badges(newlyAwardedBadges != null ? newlyAwardedBadges : List.of())
                 .build();
     }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #117 

## Work Description ✏️
<!-- 작업 내용을 간단히 소개주세요 -->
기존에는 남은 오늘 할 일의 수와 밀린 일 수를 모두 반환했었는데, (오늘 할 일 view 에서 필요함)
이 카운트들은 오늘 할 일 view 필터링 API 에서 모두 내려주기 때문에 굳이 중복해서 내려줄 필요가 없다고 프론트 사장님들과 논의했습니다.
따라서 카운팅은 내려주지 않고, 뱃지를 획득했을때는 뱃지 리스트, 획득하지 않았을 때는 빈 뱃지 리스트를 반환합니다.

<img width="729" alt="image" src="https://github.com/user-attachments/assets/1c9a8e7a-7c19-475e-9f81-0cec0450dcce" />

<img width="746" alt="image" src="https://github.com/user-attachments/assets/acc299de-db8c-4d27-91fc-f08c49796400" />
