### PR TITLE
✏️ [fix] #139 시험 지난 공부 조각들은 오늘 할 일 view 에서 보이지 않도록 수정

### DIFF
--- a/src/main/java/com/sopt/bbangzip/domain/piece/api/controller/PieceController.java
+++ b/src/main/java/com/sopt/bbangzip/domain/piece/api/controller/PieceController.java
@@ -54,7 +54,7 @@ public class PieceController {
     }
 
     @DeleteMapping("/studies/pieces")
-    public ResponseEntity<ResponseDto<List<Object>>>  deletePieces(
+    public ResponseEntity<ResponseDto<List<Object>>> deletePieces(
             @UserId final Long userId,
             @RequestBody @Valid final PieceDeleteRequestDto pieceDeleteRequestDto
     ) {

--- a/src/main/java/com/sopt/bbangzip/domain/piece/repository/PieceRepository.java
+++ b/src/main/java/com/sopt/bbangzip/domain/piece/repository/PieceRepository.java
@@ -52,6 +52,7 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
                 FROM Piece p
                 WHERE p.isVisible = true
                    AND p.isFinished = false
+                   AND p.study.exam.examDate >= CURRENT_DATE
                    AND p.study.exam.subject.userSubject.user.id = :userId
             """)
     int countUnfinishedTodayPieces(Long userId);
@@ -68,6 +69,7 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
             WHERE p.isVisible = true
                 AND p.isFinished = true
                 AND p.study.exam.subject.userSubject.user.id = :userId
+                AND p.study.exam.examDate >= CURRENT_DATE
             """)
     int countFinishedTodayPieces(Long userId);
 
@@ -82,6 +84,7 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
                AND p.isFinished=false
                AND p.deadline < CURRENT DATE
                AND p.study.exam.subject.userSubject.user.id = :userId
+               AND p.study.exam.examDate >= CURRENT_DATE
             """)
     int countPendingTodayPieces(Long userId);
 
@@ -98,6 +101,7 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
                 AND p.study.exam.subject.userSubject.year = :year
                 AND p.study.exam.subject.userSubject.semester = :semester
                 AND p.isVisible = true
+                AND p.study.exam.examDate >= CURRENT_DATE
             ORDER BY p.createdAt DESC, p.pieceNumber ASC
             """)
     List<Piece> findTodoPiecesByRecentOrder(Long userId, int year, String semester);
@@ -117,6 +121,7 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
                 AND p.isVisible = true
                 AND p.study.exam.subject.userSubject.year = :year
                 AND p.study.exam.subject.userSubject.semester = :semester
+                AND p.study.exam.examDate >= CURRENT_DATE
             ORDER BY p.pageAmount ASC, p.deadline ASC,
                      p.study.exam.subject.subjectName ASC,
                      p.pieceNumber ASC
@@ -138,6 +143,7 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
                 AND p.study.exam.subject.userSubject.year = :year
                 AND p.study.exam.subject.userSubject.semester = :semester
                 AND p.isVisible = true
+                AND p.study.exam.examDate >= CURRENT_DATE
             ORDER BY p.deadline ASC,
                      p.pageAmount ASC,
                      p.study.exam.subject.subjectName ASC,
@@ -160,6 +166,7 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
                 AND p.deadline < CURRENT_DATE
                 AND p.study.exam.subject.userSubject.year = :year
                 AND p.study.exam.subject.userSubject.semester = :semester
+                AND p.study.exam.examDate >= CURRENT_DATE
             ORDER BY p.createdAt DESC, p.pieceNumber ASC
             """)
     List<Piece> findPendingPiecesByRecentOrder(Long userId, int year, String semester);
@@ -181,6 +188,7 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
                 AND p.deadline < CURRENT_DATE
                 AND p.study.exam.subject.userSubject.year = :year
                 AND p.study.exam.subject.userSubject.semester = :semester
+                AND p.study.exam.examDate >= CURRENT_DATE
             ORDER BY p.pageAmount ASC, p.deadline ASC,
                      p.study.exam.subject.subjectName ASC, p.pieceNumber ASC
             """)
@@ -203,6 +211,8 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
                 AND p.deadline < CURRENT_DATE
                 AND p.study.exam.subject.userSubject.year = :year
                 AND p.study.exam.subject.userSubject.semester = :semester
+                AND p.study.exam.examDate >= CURRENT_DATE
+                
             ORDER BY p.deadline ASC, p.pageAmount ASC, 
                      p.study.exam.subject.subjectName ASC, p.pieceNumber ASC
             """)
@@ -219,6 +229,7 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
                        AND p.isFinished = false
                        AND p.deadline >= CURRENT DATE
                        AND p.study.exam.subject.userSubject.user.id = :userId
+                       AND p.study.exam.examDate >= CURRENT_DATE
             """)
     int findAddTodoPieceCount(Long userId, int year, String semester);
 
@@ -237,6 +248,7 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
                 AND p.isVisible = false
                 AND p.isFinished = false
                 AND p.deadline >= CURRENT_DATE
+                AND p.study.exam.examDate >= CURRENT_DATE     
             ORDER BY p.createdAt DESC, p.pieceNumber ASC
             """)
     List<Piece> findAddTodoPieceListByRecentOrder(Long userId, int year, String semester);
@@ -258,6 +270,7 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
                 AND p.isVisible = false
                 AND p.isFinished = false
                 AND p.deadline >= CURRENT_DATE
+                AND p.study.exam.examDate >= CURRENT_DATE
             ORDER BY p.pageAmount ASC,
                      p.deadline ASC,
                      p.study.exam.subject.subjectName ASC,
@@ -282,6 +295,7 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
                 AND p.isVisible = false
                 AND p.isFinished = false
                 AND p.deadline >= CURRENT_DATE
+                AND p.study.exam.examDate >= CURRENT_DATE
             ORDER BY p.deadline ASC,
                      p.pageAmount ASC,
                      p.study.exam.subject.subjectName ASC,


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #139 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
piece 테이블입니다.
중간고사는 exam id 가 1,3 이므로 , exam id 가 1,3인 piece 조각을 빼고 밀린 일이 2개 입니다.
<img width="1074" alt="image" src="https://github.com/user-attachments/assets/488cd76a-f64a-4043-a19b-3191c436cf58" />


제대로 카운팅 되는 것을 확인하실 수 있습니다.
<img width="1024" alt="image" src="https://github.com/user-attachments/assets/d91b54ed-1b9b-4c59-b91e-e45fe816e4c0" />
