### PR TITLE
✏️ [fix] #146 과목 삭제를 위한 Exam 엔티티 수정

### DIFF
--- a/src/main/java/com/sopt/bbangzip/domain/exam/entity/Exam.java
+++ b/src/main/java/com/sopt/bbangzip/domain/exam/entity/Exam.java
@@ -1,6 +1,7 @@
 package com.sopt.bbangzip.domain.exam.entity;
 
 import com.sopt.bbangzip.common.constants.entity.ExamTableConstants;
+import com.sopt.bbangzip.domain.study.entity.Study;
 import com.sopt.bbangzip.domain.subject.entity.Subject;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -42,5 +44,8 @@ public class Exam {
         this.examDate = examDate;
         this.createdAt = LocalDateTime.now();
     }
+
+    @OneToMany(mappedBy = "exam", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Study> studies;
 
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #146 

## Work Description ✏️

연관관계 매핑 수정 후 과목 삭제가 잘 됩니다 !
```
    @OneToMany(mappedBy = "exam", cascade = CascadeType.ALL, orphanRemoval = true)
    private List<Study> studies;
```

![image](https://github.com/user-attachments/assets/6246465d-650b-4ddc-8daa-1fca678ae0cd)



## To Reviewers 📢

`cascade = CascadeType.ALL` 로 설정했는데 혹시 `cascade = CascadeType.Remove`로 바꿔야할까요 ?
코멘트 남겨주세용 !!
