### PR TITLE
✏️ [fix] #152 중간/기말 선택 필터링 API 및 교재 추가하기 API 로직 오류 수정

### DIFF
--- a/src/main/java/com/sopt/bbangzip/domain/exam/api/dto/response/ExamResponseDto.java
+++ b/src/main/java/com/sopt/bbangzip/domain/exam/api/dto/response/ExamResponseDto.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 @Builder
 public record ExamResponseDto(
+        String subjectName,
         String motivationMessage,
         int examDday,
         String examDate,

--- a/src/main/java/com/sopt/bbangzip/domain/exam/entity/Exam.java
+++ b/src/main/java/com/sopt/bbangzip/domain/exam/entity/Exam.java
@@ -28,10 +28,13 @@ public class Exam {
     @JoinColumn(name = ExamTableConstants.COLUMN_SUBJECT_ID, nullable = false)
     private Subject subject;
 
+    @OneToMany(mappedBy = "exam", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Study> studies;
+
     @Column(name = ExamTableConstants.COLUMN_EXAM_NAME, nullable = false)
     private String examName;
 
-    @Column(name = ExamTableConstants.COLUMN_EXAM_DATE)
+    @Column(name = ExamTableConstants.COLUMN_EXAM_DATE, nullable = true)
     private LocalDate examDate;
 
     @Column(name = ExamTableConstants.COLUMN_CREATED_AT, nullable = false, updatable = false)
@@ -45,7 +48,8 @@ public class Exam {
         this.createdAt = LocalDateTime.now();
     }
 
-    @OneToMany(mappedBy = "exam", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Study> studies;
+    public void updateExamDate(LocalDate examDate) {
+        this.examDate = examDate;
+    }
 
 }

--- a/src/main/java/com/sopt/bbangzip/domain/exam/repository/ExamRepository.java
+++ b/src/main/java/com/sopt/bbangzip/domain/exam/repository/ExamRepository.java
@@ -36,5 +36,23 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
     );
 
     Optional<Exam> findByExamNameAndExamDateAndSubject(String examName, LocalDate examDate, Subject subject);
+
+    @Query("""
+             SELECT e
+             FROM Exam e
+             JOIN e.subject s
+             JOIN s.userSubject us
+             JOIN us.user u
+             WHERE e.examName = :examName
+               AND e.examDate = :examDate
+               AND s = :subject
+               AND u.id = :userId
+            """)
+    Optional<Exam> findByExamNameAndExamDateAndSubjectAndUser(
+            @Param("userId") Long userId,
+            @Param("examName") String examName,
+            @Param("examDate") LocalDate examDate,
+            @Param("subject") Subject subject
+    );
 }
 

--- a/src/main/java/com/sopt/bbangzip/domain/exam/service/ExamRetriever.java
+++ b/src/main/java/com/sopt/bbangzip/domain/exam/service/ExamRetriever.java
@@ -18,13 +18,18 @@ import java.util.Optional;
 public class ExamRetriever {
     private final ExamRepository examRepository;
 
-        public Exam findBySubjectIdAndExamNameAndUser(final Long userId, final String examName, final Long subjectId) {
+    public Exam findBySubjectIdAndExamNameAndUser(final Long userId, final String examName, final Long subjectId) {
         return examRepository.findBySubjectIdAndExamNameAndUser(userId, examName, subjectId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_EXAM));
     }
 
-    public Optional<Exam> findByExamNameAndDateAndSubject(String examName, LocalDate examDate, Subject subject) {
-        return examRepository.findByExamNameAndExamDateAndSubject(examName, examDate, subject);
+    public Optional<Exam> findByExamNameAndExamDateAndSubjectAndUser(
+            final Long userId,
+            final String examName,
+            final LocalDate examDate,
+            final Subject subject
+    ){
+        return examRepository.findByExamNameAndExamDateAndSubjectAndUser(userId, examName, examDate, subject);
     }
 
 }

--- a/src/main/java/com/sopt/bbangzip/domain/exam/service/ExamService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/exam/service/ExamService.java
@@ -4,7 +4,10 @@ import com.sopt.bbangzip.common.exception.base.InvalidOptionsException;
 import com.sopt.bbangzip.common.exception.code.ErrorCode;
 import com.sopt.bbangzip.domain.exam.api.dto.response.ExamResponseDto;
 import com.sopt.bbangzip.domain.exam.entity.Exam;
+import com.sopt.bbangzip.domain.exam.repository.ExamRepository;
 import com.sopt.bbangzip.domain.piece.service.PieceRetriever;
+import com.sopt.bbangzip.domain.subject.entity.Subject;
+import com.sopt.bbangzip.domain.subject.service.SubjectRetriever;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -19,8 +22,11 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class ExamService {
-    private final ExamRetriever examRetriever;
+
+    private final ExamRepository examRepository;
     private final PieceRetriever pieceRetriever;
+
+    private final SubjectRetriever subjectRetriever;
 
     /**
      * 시험 정보 조회 및 examName 변환
@@ -39,7 +45,16 @@ public class ExamService {
             default -> throw new InvalidOptionsException(ErrorCode.INVALID_ARGUMENTS);
         };
 
-        Exam exam = examRetriever.findBySubjectIdAndExamNameAndUser(userId, convertedExamName, subjectId);
+        // 과목 조회
+        Subject subject = subjectRetriever.findByIdAndUserId(userId, subjectId);
+
+        // 시험 조회하는데 없으면 만들기
+        Exam exam = examRepository.findBySubjectIdAndExamNameAndUser(userId, convertedExamName, subjectId)
+                .orElseGet(() -> {
+                    createDefaultExams(subject);
+                    return examRepository.findBySubjectIdAndExamNameAndUser(userId, convertedExamName, subjectId)
+                            .orElseThrow(() -> new IllegalStateException("기본 시험 생성에 실패했습니다"));
+                });
 
         List<ExamResponseDto.StudyPiece> studyList = pieceRetriever.findByStudyExamIdAndUserId(userId, exam.getId())
                 .stream()
@@ -54,14 +69,33 @@ public class ExamService {
                         .build())
                 .collect(Collectors.toList());
 
-        int examDday = (int) ChronoUnit.DAYS.between(exam.getExamDate(), LocalDate.now());
+        // 시험 날짜가 없을 경우 D-Day는 반환하지 않음
+        Integer examDday = exam.getExamDate() != null ? (int) ChronoUnit.DAYS.between(exam.getExamDate(), LocalDate.now()) : null;
         String motivationMessage = exam.getSubject().getMotivationMessage();
 
         return ExamResponseDto.builder()
+                .subjectName(subject.getSubjectName())
                 .motivationMessage(motivationMessage)
-                .examDday(examDday)
-                .examDate(exam.getExamDate().toString())
+                .examDday(examDday != null ? examDday : -1) // 기본값 -1 설정
+                .examDate(exam.getExamDate() != null ? exam.getExamDate().toString() : "Not Scheduled")
                 .studyList(studyList)
                 .build();
+    }
+
+    public void createDefaultExams(final Subject subject) {
+        Exam midExam = Exam.builder()
+                .examName("중간고사")
+                .examDate(null)
+                .subject(subject)
+                .build();
+
+        Exam finalExam = Exam.builder()
+                .examName("기말고사")
+                .examDate(null)
+                .subject(subject)
+                .build();
+
+        examRepository.saveAll(List.of(midExam, finalExam));
+        log.info("기본 시험 생성: 중간고사, 기말고사 for subjectId={}", subject.getId());
     }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/study/api/controller/StudyController.java
+++ b/src/main/java/com/sopt/bbangzip/domain/study/api/controller/StudyController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class StudyController {
     private final StudyService studyService;
 
+    // 교재 추가하기 API
     @PostMapping("/studies")
     public ResponseEntity<CreateStudyResponse> createStudy(
             @UserId final long userId,

--- a/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectService.java
@@ -41,6 +41,7 @@ public class SubjectService {
     private final UserSubjectSaver userSubjectSaver;
     private final SubjectUpdater subjectUpdater;
 
+    @Transactional
     public void createSubject(
             final Long userId,
             final SubjectCreateDto subjectCreateDto
@@ -72,16 +73,15 @@ public class SubjectService {
         subjectSaver.save(subject);
     }
 
+    @Transactional
     public void deleteSubject(
             final Long userId,
             final SubjectDeleteDto subjectDeleteDto
     ) {
-        // 유저 검증
         userRetriever.findByUserId(userId);
 
         // 주어진 연도와 학기에 대한 UserSubject 조회
         UserSubject userSubject = subjectRetriever.findByUserIdAndYearAndSemester(userId, subjectDeleteDto.year(), subjectDeleteDto.semester());
-
         if (userSubject == null) {throw new NotFoundException(ErrorCode.NOT_FOUND_USER_SUBJECT); }
 
         // 삭제할 과목 조회
@@ -90,8 +90,6 @@ public class SubjectService {
         if (subjects.isEmpty()) {
             throw new NotFoundException(ErrorCode.NOT_FOUND_SUBJECT);
         }
-
-        // SubjectRemover를 통해 삭제 처리
         subjectRemover.removeSubjects(subjects);
     }
 


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #152 

## Work Description ✏️
<!-- 작업 내용을 간단히 소개주세요 -->
- 중간/기말 필터링 할 때 과목명도 함께 내려줍니다.
  - 과목 명 수정하고 나서 바로 이 API 호출하기 때문에, 업데이트된 과목명 보여주려면 필요함.

- 공부조각 아무것도 추가 안했을 때 과목 눌러서 들어가면 존재하지 않는 시험이라는 에러 뜨는거 해결했습니다.
  - 이전 로직에서는 공부 추가할 때만 시험을 등록하는 로직이라서 에러가 발생했습니다.
  - 유저가 공부할 내용을 등록하지 않았을 때, 과목을 눌러서 과목 상세조회 페이지로 들어가면 디폴트로 중간고사, 기말고사를 등록하는 로직으로 수정했습니다.
  - 이에 따라서 교재를 추가할 때도, 새로운 시험을 만드는 것이 아니라, 디폴트로 등록했던 중간, 기말고사를 찾아와서 교재를 추가하고 해당 시험의 정보(시험 날짜, 시험까지 남은 일수)를 업데이트 하는 로직으로 수정했습니다.


application.yml 에 update 되어있어서
ALTER TABLE exam ALTER COLUMN exam_date DROP NOT NULL;
작업도 추가로 수행해 주었습니다.


