### PR TITLE
✏️ [fix] #153 Exam d-day 반환 수정

### DIFF
--- a/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectService.java
@@ -149,7 +149,7 @@ public class SubjectService {
             final Long subjectId,
             final Exam exam
     ){
-        int dDay = (int) ChronoUnit.DAYS.between(LocalDate.now(), exam.getExamDate());
+        int dDay = (int) ChronoUnit.DAYS.between(exam.getExamDate(), LocalDate.now());
 
         // 시험별 남은 공부와 밀린 공부 조회
         int remainingCount = pieceRetriever.findRemainingCount(userId, subjectId, exam.getId());


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #153

## Work Description ✏️

[수정 전]
```
{
    "code": "success",
    "data": {
        "year": 2025,
        "semester": "1학기",
        "subjectList": [
            {
                "subjectId": 1,
                "subjectName": "브랜드마케팅",
                "studyList": [
                    {
                        "examName": "중간고사",
                        "examDDay": -12,
                        "pendingCount": 2,
                        "remainingCount": 0
                    },
                    {
                        "examName": "기말고사",
                        "examDDay": 9,
                        "pendingCount": 0,
                        "remainingCount": 0
                    }
                ]
            },
            {
                "subjectId": 2,
                "subjectName": "교양 스페인어",
                "studyList": [
                    {
                        "examName": "중간고사",
                        "examDDay": -12,
                        "pendingCount": 0,
                        "remainingCount": 0
                    },
                    {
                        "examName": "기말고사",
                        "examDDay": 9,
                        "pendingCount": 0,
                        "remainingCount": 0
                    }
                ]
            }
        ]
    }
}
```

[수정 후]
지나간 시험이 +12, 남은 시험이 -9로 바뀌게 수정했습니다.


## To Reviewers 📢

또 고칠 게 있다면 알려주세요 !
