### PR TITLE
✏️ [fix] #159 과목 명 수정 시 동일 과목명으로 수정 불가

### DIFF
--- a/src/main/java/com/sopt/bbangzip/domain/subject/repository/SubjectRepository.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/repository/SubjectRepository.java
@@ -68,4 +68,14 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
            """)
     List<Subject> findSubjectsByUserAndSemester(Long userId, int year, String semester);
 
+    // 동일한 과목명이 있을 경우 확인
+    @Query("""
+        SELECT CASE WHEN COUNT(s) > 0 THEN TRUE ELSE FALSE END 
+        FROM Subject s 
+        JOIN s.userSubject us
+        WHERE us.user.id = :userId AND s.subjectName = :subjectName
+       """)
+    boolean existsByUserIdAndSubjectName(@Param("userId") Long userId,
+                                         @Param("subjectName") String subjectName);
+
 }

--- a/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectRetriever.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectRetriever.java
@@ -68,4 +68,8 @@ public class SubjectRetriever {
     public List<Subject> findSubjectsByUserAndSemester(final Long userId, final int year, final String semester) {
         return subjectRepository.findSubjectsByUserAndSemester(userId, year, semester);
     }
+
+    public boolean existsByUserIdAndSubjectName(Long userId, String subjectName) {
+        return subjectRepository.existsByUserIdAndSubjectName(userId, subjectName);
+    }
 }

--- a/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectService.java
+++ b/src/main/java/com/sopt/bbangzip/domain/subject/service/SubjectService.java
@@ -102,8 +102,14 @@ public class SubjectService {
     ){
         userRetriever.findByUserId(userId);
         Subject subject = subjectRetriever.findByIdAndUserId(userId, subjectId);
+
         switch (options) {
-            case "subjectName" -> subjectUpdater.updateSubjectName(subject, value);
+            case "subjectName" -> {
+                if (subjectRetriever.existsByUserIdAndSubjectName(userId, value)) {
+                    throw new NotFoundException(ErrorCode.DUPLICATED_SUBJECT);
+                }
+                subjectUpdater.updateSubjectName(subject, value);
+            }
             case "motivationMessage" -> subjectUpdater.updateMotivationMessage(subject, value);
             default -> throw new InvalidOptionsException(ErrorCode.INVALID_OPTION);
         }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #159 

## Work Description ✏️
이미 등록된 과목명으로 수정했을 경우, 예외처리를 추가했습니다.
![image](https://github.com/user-attachments/assets/23bf188c-b756-4d2d-8c3f-2b9b9447ff1d)


## To Reviewers 📢

이미 과목을 알고 있음에도 과목id와 user를 찾는 로직이 있는데 해당 부분은 무시해주시면 될 것 같아요 !
