### PR TITLE
:recycle: [refac] 응답 코드 String 에서 int 로 변경

### DIFF
--- a/src/main/java/com/sopt/bbangzip/common/dto/ResponseDto.java
+++ b/src/main/java/com/sopt/bbangzip/common/dto/ResponseDto.java
@@ -5,12 +5,12 @@ import com.sopt.bbangzip.common.exception.code.BbangzipErrorCode;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ResponseDto<T> (
-        String code,
+        int code,
         T data,
         String message
 ) {
     public static <T> ResponseDto<T> success(final T data) {
-        return new ResponseDto<>("success", data, null);
+        return new ResponseDto<>(0, data, null);
     }
 
     public static <T> ResponseDto<T> fail(BbangzipErrorCode code) {

--- a/src/main/java/com/sopt/bbangzip/common/exception/code/BbangzipErrorCode.java
+++ b/src/main/java/com/sopt/bbangzip/common/exception/code/BbangzipErrorCode.java
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public interface BbangzipErrorCode {
     HttpStatus getHttpStatus();
-    String getCode();
+    int getCode();
     String getMessage();
 }
 

--- a/src/main/java/com/sopt/bbangzip/common/exception/code/ErrorCode.java
+++ b/src/main/java/com/sopt/bbangzip/common/exception/code/ErrorCode.java
@@ -10,42 +10,42 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode implements BbangzipErrorCode{
 
     // 400
-    INVALID_ARGUMENTS(HttpStatus.BAD_REQUEST, "error", "인자의 형식이 올바르지 않습니다."),
-    WRONG_ENTRY_POINT(HttpStatus.BAD_REQUEST, "error", "잘못된 요청입니다."),
-    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "error", "올바르지 않은 형식의 토큰입니다"),
-    INVALID_OPTION(HttpStatus.BAD_REQUEST, "error", "올바르지 않은 옵션입니다."),
+    INVALID_ARGUMENTS(HttpStatus.BAD_REQUEST, 400, "인자의 형식이 올바르지 않습니다."),
+    WRONG_ENTRY_POINT(HttpStatus.BAD_REQUEST, 400, "잘못된 요청입니다."),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, 400, "올바르지 않은 형식의 토큰입니다"),
+    INVALID_OPTION(HttpStatus.BAD_REQUEST, 400, "올바르지 않은 옵션입니다."),
 
     // 401
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "error", "인증되지 않은 사용자입니다."),
-    MALFORMED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "error", "잘못된 형식의 토큰입니다."),
-    TYPE_ERROR_JWT_TOKEN(HttpStatus.BAD_REQUEST, "error", "올바른 타입의 JWT 토큰이 아닙니다."),
-    EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "error", "만료된 토큰입니다."),
-    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "error", "유효하지 않은 리프레시 토큰입니다."),
-    UNSUPPORTED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "error", "지원하지 않는 형식의 토큰입니다."),
-    UNKNOWN_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "error", "알 수 없는 인증 토큰 오류가 발생했습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 401, "인증되지 않은 사용자입니다."),
+    MALFORMED_JWT_TOKEN(HttpStatus.BAD_REQUEST, 401, "잘못된 형식의 토큰입니다."),
+    TYPE_ERROR_JWT_TOKEN(HttpStatus.BAD_REQUEST, 401, "올바른 타입의 JWT 토큰이 아닙니다."),
+    EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, 401, "만료된 토큰입니다."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 401, "유효하지 않은 리프레시 토큰입니다."),
+    UNSUPPORTED_JWT_TOKEN(HttpStatus.BAD_REQUEST, 401, "지원하지 않는 형식의 토큰입니다."),
+    UNKNOWN_JWT_TOKEN(HttpStatus.UNAUTHORIZED, 401, "알 수 없는 인증 토큰 오류가 발생했습니다."),
 
     // 403
-    FORBIDDEN(HttpStatus.FORBIDDEN, "error", "접근 권한이 없습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, 403, "접근 권한이 없습니다."),
 
     // 404
-    NOT_FOUND_END_POINT(HttpStatus.NOT_FOUND, "error", "존재하지 않는 API입니다."),
-    NOT_FOUND_USER(HttpStatus.NOT_FOUND,"error","존재하지 않는 사용자입니다."),
-    DUPLICATED_SUBJECT(HttpStatus.NOT_FOUND, "error", "해당 학기에 과목명이 중복됩니다."),
-    NOT_FOUND_USER_SUBJECT(HttpStatus.NOT_FOUND,"error","해당 학기에 유저가 등록한 과목이 없습니다"),
-    NOT_FOUND_SUBJECT(HttpStatus.NOT_FOUND, "error", "존재하지 않는 과목입니다."),
-    NOT_FOUND_TOKEN(HttpStatus.NOT_FOUND, "error", "존재하지 않는 토큰입니다"),
-    NOT_FOUND_PIECE(HttpStatus.NOT_FOUND, "error", "존재하지 않는 Piece 입니다"),
-    NOT_FOUND_STUDY(HttpStatus.NOT_FOUND, "error", "존재하지 않는 공부범위(교재)입니다"),
-    NOT_FOUND_EXAM(HttpStatus.NOT_FOUND, "error", "존재하지 않는 시험입니다."),
-    NOT_FOUND_BADGE(HttpStatus.NOT_FOUND, "error", "존재하지 않는 뱃지입니다."),
+    NOT_FOUND_END_POINT(HttpStatus.NOT_FOUND, 404, "존재하지 않는 API입니다."),
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND,404,"존재하지 않는 사용자입니다."),
+    DUPLICATED_SUBJECT(HttpStatus.NOT_FOUND, 404, "해당 학기에 과목명이 중복됩니다."),
+    NOT_FOUND_USER_SUBJECT(HttpStatus.NOT_FOUND,404,"해당 학기에 유저가 등록한 과목이 없습니다"),
+    NOT_FOUND_SUBJECT(HttpStatus.NOT_FOUND, 404, "존재하지 않는 과목입니다."),
+    NOT_FOUND_TOKEN(HttpStatus.NOT_FOUND, 404, "존재하지 않는 토큰입니다"),
+    NOT_FOUND_PIECE(HttpStatus.NOT_FOUND, 404, "존재하지 않는 Piece 입니다"),
+    NOT_FOUND_STUDY(HttpStatus.NOT_FOUND, 404, "존재하지 않는 공부범위(교재)입니다"),
+    NOT_FOUND_EXAM(HttpStatus.NOT_FOUND, 404, "존재하지 않는 시험입니다."),
+    NOT_FOUND_BADGE(HttpStatus.NOT_FOUND, 404, "존재하지 않는 뱃지입니다."),
 
     // 500
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "error", "서버 내부 오류입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "서버 내부 오류입니다."),
     ;
 
     @JsonIgnore
     private final HttpStatus httpStatus;
-    private final String code;
+    private final int code;
     private final String message;
 
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #177 

## Work Description ✏️
<!-- 작업 내용을 간단히 소개주세요 -->

- 성공 응답은 기존에 String 값인 "success"에서 int 값인 0으로 고정시켜서 반환합니다.
![image](https://github.com/user-attachments/assets/73de639a-b55f-41ec-9910-4abf01d8954a)

- 실패 응답은 기존에 String 값인 "error"에서 적절한 오류 상황에 대한 HttpStatus Code 값을 Int 로 반환합니다.
![image](https://github.com/user-attachments/assets/3b88d04a-45ed-421f-9462-67cdeae7fc7b)


## Uncompleted Tasks 😅
<!-- 끝내지 못한 작업을 적어주세요 -->
추후 스프린트 때 여유기 된디면! 아래와 깉이 에러코드를 세분화 하면 좋을 것 같습니다.
![image](https://github.com/user-attachments/assets/dfbc6ef2-7eb6-4586-9370-e3fb398324e4)
![image](https://github.com/user-attachments/assets/b02a5a07-3882-4bed-af03-9441dda9fd67)


